### PR TITLE
feat: Icon hover and disable state

### DIFF
--- a/packages/react-packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react-packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
@@ -62,6 +62,16 @@ exports[`<Accordion /> component should render with correct style when hasBackgr
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
 }
 
 .emotion-6 {
@@ -183,6 +193,16 @@ exports[`<Accordion /> component should render with correct style when hasBackgr
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
 }
 
 .emotion-6 {

--- a/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
@@ -68,6 +68,16 @@ exports[`<CheckBox /> component renders checkbox checked 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-6:hover,
+.emotion-6:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/dropdown/package.json
+++ b/packages/react-packages/dropdown/package.json
@@ -23,6 +23,7 @@
     "@dt-ui/react-box": "0.1.0-beta.8",
     "@dt-ui/react-core": "0.1.0-beta.39",
     "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
     "@dt-ui/react-typography": "0.1.0-beta.30"
   },
   "devDependencies": {

--- a/packages/react-packages/dropdown/src/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-packages/dropdown/src/__snapshots__/Dropdown.test.tsx.snap
@@ -94,6 +94,16 @@ exports[`<Dropdown /> component renders dropdown correctly 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-10:hover,
+.emotion-10:active {
+  color: #00677F;
 }
 
 .emotion-12 {

--- a/packages/react-packages/dropdown/src/components/select/DropdownSelect.tsx
+++ b/packages/react-packages/dropdown/src/components/select/DropdownSelect.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@dt-ui/react-box';
 import { BaseProps } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { Typography } from '@dt-ui/react-typography';
 import { useTheme } from '@emotion/react';
 import { Children, ReactElement, useEffect } from 'react';
@@ -124,13 +125,14 @@ export const DropdownSelect = ({
         </div>
         <Box style={{ flexDirection: 'row', gap: '0.5rem' }}>
           {hasDeselect && !!state.value ? (
-            <Icon
-              code='close'
-              color={disabledIconColor}
-              dataTestId='deselect-value'
-              onClick={handleDeselectClick}
-              size='s'
-            />
+            <IconButton onClick={handleDeselectClick}>
+              <Icon
+                code='close'
+                color={disabledIconColor}
+                dataTestId='deselect-value'
+                size='s'
+              />
+            </IconButton>
           ) : null}
           <Icon
             code={isOpen ? 'expand_less' : 'expand_more'}

--- a/packages/react-packages/icon-button/src/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/react-packages/icon-button/src/__snapshots__/IconButton.test.tsx.snap
@@ -46,6 +46,16 @@ exports[`<IconButton /> component should have style if variant is contrast and i
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>
@@ -110,6 +120,16 @@ exports[`<IconButton /> component should have style if variant is contrast and i
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>
@@ -175,6 +195,16 @@ exports[`<IconButton /> component should have style if variant is default and is
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>
@@ -239,6 +269,16 @@ exports[`<IconButton /> component should have style if variant is default and is
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/icon/README.md
+++ b/packages/react-packages/icon/README.md
@@ -22,6 +22,8 @@ export const App = () => {
 | `variant`    | 'outlined' \| 'filled' | 'outlined' | Specifies the icon filling variant.                                                        |
 | `dataTestId` | `string`               | 'icon'     | Customizable test identifier.                                                              |
 | `style`      | `React.CSSProperties`  | -          | Additional styles to apply to the icon.                                                    |
+| `isDisabled` | `boolean`              | false      | Determines the disabled state of the button                                                |
+
 
 ## Stack
 

--- a/packages/react-packages/icon/src/Icon.stories.tsx
+++ b/packages/react-packages/icon/src/Icon.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta<IconProps> = {
       options: Object.keys(fontSize),
       control: { type: 'radio' },
     },
+    isDisabled: {
+      control: 'boolean',
+    },
   },
   parameters: {
     controls: {
@@ -39,5 +42,6 @@ export const Default: StoryObj<IconProps> = {
     size: 'l',
     variant: 'outlined',
     color: 'black',
+    isDisabled: false,
   },
 };

--- a/packages/react-packages/icon/src/Icon.styled.ts
+++ b/packages/react-packages/icon/src/Icon.styled.ts
@@ -6,7 +6,7 @@ interface IconStyledProps {
   color: string;
   size: Size;
   variant: Variant;
-  hasClick: boolean;
+  disabled?: boolean;
 }
 
 export const fontSize: Record<Size, string> = {
@@ -18,7 +18,7 @@ export const fontSize: Record<Size, string> = {
 };
 
 export const IconStyled = styled.i<IconStyledProps>`
-  ${({ size, theme, variant, color, hasClick }) => `
+  ${({ size, theme, variant, color, disabled }) => `
     font-family: DTUI-icons-${theme.icons};
     font-weight: normal;
     font-style: normal;
@@ -30,7 +30,7 @@ export const IconStyled = styled.i<IconStyledProps>`
     word-wrap: normal;
     white-space: nowrap;
     font-variation-settings: 'FILL' ${variant === 'filled' ? 1 : 0};
-    color: ${color};
+    color: ${disabled ? theme.palette.content.light : color};
 
     /* Support for all WebKit browsers. */
     -webkit-font-smoothing: antialiased;
@@ -43,12 +43,13 @@ export const IconStyled = styled.i<IconStyledProps>`
     /* Support for IE. */
     font-feature-settings: 'liga';
 
-    ${
-      hasClick &&
-      `
-        cursor: pointer;
-        user-select: none;
-      `
-    };
+    cursor: ${disabled ? 'not-allowed' : 'pointer'};
+    user-select: none;
+
+      &:hover, &:active {
+        color: ${
+          !disabled ? theme.palette.accent.default : theme.palette.content.light
+        };
+      }
   `}
 `;

--- a/packages/react-packages/icon/src/Icon.test.tsx
+++ b/packages/react-packages/icon/src/Icon.test.tsx
@@ -16,7 +16,8 @@ describe('Icon component tests', () => {
   it('applies the specified color in the Icon component', () => {
     const { container } = render(<ProvidedIcon code={CODE} color='red' />);
 
-    expect(container.querySelector('i')).toHaveStyle('color: red');
+    const iconElement = container.querySelector('i');
+    expect(iconElement).toHaveStyleRule('color', 'red');
   });
 
   it.each`
@@ -44,4 +45,29 @@ describe('Icon component tests', () => {
       "font-variation-settings: 'FILL' 1"
     );
   });
+
+  it('applies disabled style in the Icon component', () => {
+    const { container } = render(<ProvidedIcon code={CODE} isDisabled />);
+    const iconElement = container.querySelector('i');
+
+    expect(iconElement).toHaveStyle('color: #A3A3A3');
+    expect(iconElement).toHaveAttribute('disabled');
+  });
+
+  it.each`
+    variant       | isDisabled
+    ${'outlined'} | ${false}
+    ${'outlined'} | ${false}
+    ${'filled'}   | ${false}
+    ${'filled'}   | ${true}
+  `(
+    'should have style if variant is $variant and isDisabled is $isDisabled',
+    ({ variant, isDisabled }) => {
+      const { container } = render(
+        <ProvidedIcon code={CODE} isDisabled={isDisabled} variant={variant} />
+      );
+
+      expect(container).toMatchSnapshot();
+    }
+  );
 });

--- a/packages/react-packages/icon/src/Icon.tsx
+++ b/packages/react-packages/icon/src/Icon.tsx
@@ -10,7 +10,7 @@ export interface IconProps extends Omit<BaseProps, 'children'> {
   color?: string;
   size?: Size;
   variant?: Variant;
-  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  isDisabled?: boolean;
 }
 
 export const Icon = ({
@@ -20,7 +20,7 @@ export const Icon = ({
   size = 'l',
   style,
   variant = 'outlined',
-  onClick,
+  isDisabled,
 }: IconProps) => {
   const theme = useTheme();
 
@@ -28,8 +28,7 @@ export const Icon = ({
     <IconStyled
       color={color ?? theme.palette.content.default}
       data-testid={dataTestId ?? 'icon'}
-      hasClick={!!onClick}
-      onClick={onClick}
+      disabled={isDisabled}
       size={size}
       style={style}
       variant={variant}

--- a/packages/react-packages/icon/src/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react-packages/icon/src/__snapshots__/Icon.test.tsx.snap
@@ -18,6 +18,181 @@ exports[`Icon component tests renders Icon component 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  color: #00677F;
+}
+
+<div>
+  <i
+    class="emotion-0 emotion-1"
+    color="#292929"
+    data-testid="icon"
+  >
+    warning
+  </i>
+</div>
+`;
+
+exports[`Icon component tests should have style if variant is filled and isDisabled is false 1`] = `
+.emotion-0 {
+  font-family: DTUI-icons-outlined;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  font-variation-settings: 'FILL' 1;
+  color: #292929;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  color: #00677F;
+}
+
+<div>
+  <i
+    class="emotion-0 emotion-1"
+    color="#292929"
+    data-testid="icon"
+  >
+    warning
+  </i>
+</div>
+`;
+
+exports[`Icon component tests should have style if variant is filled and isDisabled is true 1`] = `
+.emotion-0 {
+  font-family: DTUI-icons-outlined;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  font-variation-settings: 'FILL' 1;
+  color: #A3A3A3;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+  cursor: not-allowed;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  color: #A3A3A3;
+}
+
+<div>
+  <i
+    class="emotion-0 emotion-1"
+    color="#292929"
+    data-testid="icon"
+    disabled=""
+  >
+    warning
+  </i>
+</div>
+`;
+
+exports[`Icon component tests should have style if variant is outlined and isDisabled is false 1`] = `
+.emotion-0 {
+  font-family: DTUI-icons-outlined;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  font-variation-settings: 'FILL' 0;
+  color: #292929;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  color: #00677F;
+}
+
+<div>
+  <i
+    class="emotion-0 emotion-1"
+    color="#292929"
+    data-testid="icon"
+  >
+    warning
+  </i>
+</div>
+`;
+
+exports[`Icon component tests should have style if variant is outlined and isDisabled is false 2`] = `
+.emotion-0 {
+  font-family: DTUI-icons-outlined;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  font-variation-settings: 'FILL' 0;
+  color: #292929;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/link/src/__snapshots__/Link.test.tsx.snap
+++ b/packages/react-packages/link/src/__snapshots__/Link.test.tsx.snap
@@ -195,6 +195,16 @@ exports[`<Link /> component Should render an html link element with Icon 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/modal/src/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-packages/modal/src/__snapshots__/Modal.test.tsx.snap
@@ -180,6 +180,16 @@ exports[`<Modal/> Component handle loading state renders modal with loading over
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-12:hover,
+.emotion-12:active {
+  color: #00677F;
 }
 
 .emotion-14 {
@@ -447,6 +457,16 @@ exports[`<Modal/> Component handle modal actions renders modal correctly 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-12:hover,
+.emotion-12:active {
+  color: #00677F;
 }
 
 .emotion-14 {

--- a/packages/react-packages/pagination/src/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-packages/pagination/src/__snapshots__/Pagination.test.tsx.snap
@@ -46,6 +46,16 @@ exports[`<Pagination /> component should render the pagination content 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
 }
 
 .emotion-6 {

--- a/packages/react-packages/progress-bar/src/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/react-packages/progress-bar/src/__snapshots__/ProgressBar.test.tsx.snap
@@ -644,6 +644,16 @@ exports[`<ProgressBar /> component should render with different info prop should
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-10:hover,
+.emotion-10:active {
+  color: #00677F;
 }
 
 <div>
@@ -842,6 +852,16 @@ exports[`<ProgressBar /> component should render with different info prop should
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-12:hover,
+.emotion-12:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/segmented-control/src/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/packages/react-packages/segmented-control/src/__snapshots__/SegmentedControl.test.tsx.snap
@@ -94,6 +94,16 @@ exports[`SegmentedControl renders without errors 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-6:hover,
+.emotion-6:active {
+  color: #00677F;
 }
 
 <div>

--- a/packages/react-packages/select/package.json
+++ b/packages/react-packages/select/package.json
@@ -23,6 +23,7 @@
     "@dt-ui/react-checkbox": "0.1.0-beta.37",
     "@dt-ui/react-core": "0.1.0-beta.39",
     "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
     "@dt-ui/react-label-field": "0.1.0-beta.35",
     "@dt-ui/react-tooltip": "0.1.0-beta.47",
     "@dt-ui/react-typography": "0.1.0-beta.30",

--- a/packages/react-packages/select/src/Select.tsx
+++ b/packages/react-packages/select/src/Select.tsx
@@ -1,5 +1,6 @@
 import { BaseProps, useClickOutside } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { LabelField } from '@dt-ui/react-label-field';
 import { Tooltip } from '@dt-ui/react-tooltip';
 import { Typography } from '@dt-ui/react-typography';
@@ -272,12 +273,9 @@ const Select = ({
             <SelectActionContainerStyled>
               {isMulti && hasSelectedItems ? (
                 <Tooltip>
-                  <Icon
-                    code='close'
-                    dataTestId='clear-selection'
-                    onClick={clearSelection}
-                    size='s'
-                  />
+                  <IconButton onClick={clearSelection}>
+                    <Icon code='close' dataTestId='clear-selection' size='s' />
+                  </IconButton>
                   <Tooltip.Content>Clear all</Tooltip.Content>
                 </Tooltip>
               ) : null}

--- a/packages/react-packages/select/src/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-packages/select/src/__snapshots__/Select.test.tsx.snap
@@ -123,6 +123,16 @@ exports[`<Select /> component should render Select 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-12:hover,
+.emotion-12:active {
+  color: #00677F;
 }
 
 .emotion-14 {
@@ -459,6 +469,16 @@ exports[`<Select /> component should render Select as multi select 1`] = `
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-12:hover,
+.emotion-12:active {
+  color: #00677F;
 }
 
 .emotion-14 {

--- a/packages/react-packages/stepper/src/components/Step/__snapshots__/Step.test.tsx.snap
+++ b/packages/react-packages/stepper/src/components/Step/__snapshots__/Step.test.tsx.snap
@@ -105,6 +105,16 @@ exports[`<Step /> component <Step.Counter /> component renders StepCounter with 
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  color: #00677F;
 }
 
 <div>
@@ -559,6 +569,16 @@ exports[`<Step /> component render Step renders Step with props correctly 2`] = 
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
 }
 
 .emotion-6 {

--- a/packages/react-packages/tabs/package.json
+++ b/packages/react-packages/tabs/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@dt-ui/react-core": "0.1.0-beta.39",
     "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
     "@dt-ui/react-box": "0.1.0-beta.8"
   },
   "devDependencies": {

--- a/packages/react-packages/tabs/src/Tabs.tsx
+++ b/packages/react-packages/tabs/src/Tabs.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@dt-ui/react-box';
 import { BaseProps, useDebounceResize } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { useTheme } from '@emotion/react';
 import {
   Children,
@@ -93,16 +94,13 @@ export const Tabs = ({
         }),
       }}
     >
-      <Icon
-        code='keyboard_arrow_left'
-        dataTestId='left-arrow'
-        onClick={() => handleScroll(-SCROLL_MOVEMENT)}
-        style={{
-          ...(!isLeftSideOverflowing && {
-            display: 'none',
-          }),
-        }}
-      />
+      <IconButton onClick={() => handleScroll(-SCROLL_MOVEMENT)}>
+        <Icon
+          code='keyboard_arrow_left'
+          dataTestId='left-arrow'
+          style={{ ...(!isLeftSideOverflowing && { display: 'none' }) }}
+        />
+      </IconButton>
       <TabsStyled
         data-testid={dataTestId}
         ref={ref}
@@ -112,16 +110,13 @@ export const Tabs = ({
       >
         {clonedChildren}
       </TabsStyled>
-      <Icon
-        code='keyboard_arrow_right'
-        dataTestId='right-arrow'
-        onClick={() => handleScroll(SCROLL_MOVEMENT)}
-        style={{
-          ...(!isRightSideOverflowing && {
-            display: 'none',
-          }),
-        }}
-      />
+      <IconButton onClick={() => handleScroll(SCROLL_MOVEMENT)}>
+        <Icon
+          code='keyboard_arrow_right'
+          dataTestId='right-arrow'
+          style={{ ...(!isRightSideOverflowing && { display: 'none' }) }}
+        />
+      </IconButton>
     </Box>
   );
 };

--- a/packages/react-packages/tabs/src/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-packages/tabs/src/__snapshots__/Tabs.test.tsx.snap
@@ -16,6 +16,34 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.emotion-2 i {
+  font-size: 24px;
+  color: #292929;
+}
+
+.emotion-2:not(:disabled)>i:hover,
+.emotion-2:not(:disabled)>i:active {
+  color: #00677F;
+}
+
+.emotion-2:focus-visible {
+  outline: 2px solid #000000;
+}
+
+.emotion-4 {
   font-family: DTUI-icons-outlined;
   font-weight: normal;
   font-style: normal;
@@ -39,7 +67,12 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   user-select: none;
 }
 
-.emotion-4 {
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
+}
+
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -51,7 +84,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   width: 100%;
 }
 
-.emotion-6 {
+.emotion-8 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,7 +108,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   gap: 8px;
 }
 
-.emotion-8 {
+.emotion-10 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -99,30 +132,11 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   gap: 8px;
 }
 
-.emotion-8:hover {
+.emotion-10:hover {
   background-color: #CCE3EB;
 }
 
-.emotion-12 {
-  font-family: DTUI-icons-outlined;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  font-variation-settings: 'FILL' 0;
-  color: #292929;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
-}
-
-.emotion-14 {
+.emotion-16 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -151,21 +165,26 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
     class="emotion-0 emotion-1"
     style="flex-direction: row;"
   >
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="left-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_left
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="left-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_left
+      </i>
+    </button>
     <div
-      class="emotion-4 emotion-5"
+      class="emotion-6 emotion-7"
       data-testid="tabs"
       role="tablist"
     >
       <button
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="tab-item-0"
         role="tab"
         tabindex="0"
@@ -173,7 +192,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 1
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-1"
         role="tab"
         tabindex="-1"
@@ -181,13 +200,13 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 2
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-2"
         role="tab"
         tabindex="-1"
       >
         <i
-          class="emotion-12 emotion-3"
+          class="emotion-4 emotion-5"
           color="#292929"
           data-testid="icon"
         >
@@ -196,7 +215,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 3
       </button>
       <button
-        class="emotion-14 emotion-7"
+        class="emotion-16 emotion-9"
         data-testid="tab-item-3"
         disabled=""
         role="tab"
@@ -205,14 +224,19 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 4
       </button>
     </div>
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="right-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_right
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="right-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_right
+      </i>
+    </button>
   </div>
 </div>
 `;
@@ -233,6 +257,34 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.emotion-2 i {
+  font-size: 24px;
+  color: #292929;
+}
+
+.emotion-2:not(:disabled)>i:hover,
+.emotion-2:not(:disabled)>i:active {
+  color: #00677F;
+}
+
+.emotion-2:focus-visible {
+  outline: 2px solid #000000;
+}
+
+.emotion-4 {
   font-family: DTUI-icons-outlined;
   font-weight: normal;
   font-style: normal;
@@ -256,7 +308,12 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   user-select: none;
 }
 
-.emotion-4 {
+.emotion-4:hover,
+.emotion-4:active {
+  color: #00677F;
+}
+
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -269,7 +326,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   margin-bottom: -1px;
 }
 
-.emotion-6 {
+.emotion-8 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -294,7 +351,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   gap: 8px;
 }
 
-.emotion-8 {
+.emotion-10 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -318,30 +375,11 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   gap: 8px;
 }
 
-.emotion-8:hover {
+.emotion-10:hover {
   background-color: #CCE3EB;
 }
 
-.emotion-12 {
-  font-family: DTUI-icons-outlined;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  font-variation-settings: 'FILL' 0;
-  color: #292929;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
-}
-
-.emotion-14 {
+.emotion-16 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -370,21 +408,26 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
     class="emotion-0 emotion-1"
     style="flex-direction: row; border-bottom: 1px solid #DEDEDE;"
   >
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="left-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_left
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="left-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_left
+      </i>
+    </button>
     <div
-      class="emotion-4 emotion-5"
+      class="emotion-6 emotion-7"
       data-testid="tabs"
       role="tablist"
     >
       <button
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="tab-item-0"
         role="tab"
         tabindex="0"
@@ -392,7 +435,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 1
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-1"
         role="tab"
         tabindex="-1"
@@ -400,13 +443,13 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 2
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-2"
         role="tab"
         tabindex="-1"
       >
         <i
-          class="emotion-12 emotion-3"
+          class="emotion-4 emotion-5"
           color="#292929"
           data-testid="icon"
         >
@@ -415,7 +458,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 3
       </button>
       <button
-        class="emotion-14 emotion-7"
+        class="emotion-16 emotion-9"
         data-testid="tab-item-3"
         disabled=""
         role="tab"
@@ -424,14 +467,19 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 4
       </button>
     </div>
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="right-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_right
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="right-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_right
+      </i>
+    </button>
   </div>
 </div>
 `;

--- a/packages/react-packages/text-field/package.json
+++ b/packages/react-packages/text-field/package.json
@@ -24,6 +24,7 @@
     "@dt-ui/react-spinner": "0.1.0-beta.41",
     "@dt-ui/react-label-field": "0.1.0-beta.35",
     "@dt-ui/react-typography": "0.1.0-beta.30",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
     "@dt-ui/react-icon": "0.1.0-beta.39"
   },
   "devDependencies": {

--- a/packages/react-packages/text-field/src/TextField.stories.tsx
+++ b/packages/react-packages/text-field/src/TextField.stories.tsx
@@ -23,11 +23,11 @@ type TextFieldPropsWithExtrasProp = TextFieldProps & {
 };
 
 const extraPrefix: ExtraComponent = {
-  component: <Icon code='home_work' size='large' />,
+  component: <Icon code='home_work' size='l' />,
 };
 
 const extraSuffix: ExtraComponent = {
-  component: <Icon code='home_work' size='large' />,
+  component: <Icon code='home_work' size='l' />,
 };
 
 const meta: Meta<TextFieldPropsWithExtrasProp> = {

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -1,5 +1,6 @@
 import { BaseProps } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { LabelField } from '@dt-ui/react-label-field';
 import { Typography } from '@dt-ui/react-typography';
 import {
@@ -214,7 +215,9 @@ export const TextField = ({
             onKeyDown={handleResetIconEnter}
             tabIndex={0}
           >
-            <Icon code='close_small' onClick={handleResetInput} />
+            <IconButton onClick={handleResetInput}>
+              <Icon code='close_small' />
+            </IconButton>
           </ResetInputIconStyled>
         ) : null}
 

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -378,6 +378,16 @@ exports[`<TextField /> component renders input with extras suffix and prefix ele
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.emotion-8:hover,
+.emotion-8:active {
+  color: #00677F;
 }
 
 .emotion-10 {


### PR DESCRIPTION
## Description

- Add Icon hover and disable state
- Drop Icon onClick prop (`<i>` element should not have click event)

![222222](https://github.com/user-attachments/assets/1fe9d5d0-33d6-4456-b9a4-c825ec1dc0d1)



## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview


https://daimlertruck.github.io/daimlertruck/dt-ui/PR-3