### PR TITLE
Feat: Add text field hover and focus

### DIFF
--- a/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -81,62 +81,82 @@ exports[`<DatePicker /> component onBlur event should render error message when 
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -205,6 +225,7 @@ exports[`<DatePicker /> component onBlur event should render error message when 
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -313,62 +334,82 @@ exports[`<DatePicker /> component onBlur event should render error message when 
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -437,6 +478,7 @@ exports[`<DatePicker /> component onBlur event should render error message when 
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -555,62 +597,82 @@ exports[`<DatePicker /> component should render date input correctly 1`] = `
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-6:has(input:focus) {
-  border-color: #000000;
+.emotion-6:focus-within,
+.emotion-6:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-6:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-6:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-6:has(input[readonly]:not([disabled])) {
+.emotion-6:focus-within:has(input[readonly]:not([disabled])),
+.emotion-6:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-6:has(input[disabled]),
-.emotion-6:has(input[disabled])>* {
+.emotion-6:focus-within:has(input[disabled]),
+.emotion-6:hover:has(input[disabled]),
+.emotion-6:focus-within:has(input[disabled])>*,
+.emotion-6:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-6:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input::-moz-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-6:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input::-moz-placeholder {
+.emotion-6:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-6:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input::placeholder,
-.emotion-6:has(input[disabled])>* input::placeholder {
+.emotion-6:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled]) input::placeholder,
+.emotion-6:hover:has(input[disabled]) input::placeholder,
+.emotion-6:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-6:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -672,6 +734,7 @@ exports[`<DatePicker /> component should render date input correctly 1`] = `
     </label>
     <div
       class="emotion-6 emotion-7"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-8 emotion-9"

--- a/packages/react-packages/form/src/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-packages/form/src/__snapshots__/Form.test.tsx.snap
@@ -93,62 +93,82 @@ exports[`<Form /> component renders simple form 1`] = `
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-6:has(input:focus) {
-  border-color: #000000;
+.emotion-6:focus-within,
+.emotion-6:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-6:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-6:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-6:has(input[readonly]:not([disabled])) {
+.emotion-6:focus-within:has(input[readonly]:not([disabled])),
+.emotion-6:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-6:has(input[disabled]),
-.emotion-6:has(input[disabled])>* {
+.emotion-6:focus-within:has(input[disabled]),
+.emotion-6:hover:has(input[disabled]),
+.emotion-6:focus-within:has(input[disabled])>*,
+.emotion-6:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-6:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input::-moz-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-6:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-6:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input::-moz-placeholder {
+.emotion-6:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-6:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-6:has(input[disabled]) input::placeholder,
-.emotion-6:has(input[disabled])>* input::placeholder {
+.emotion-6:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-6:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-6:focus-within:has(input[disabled]) input::placeholder,
+.emotion-6:hover:has(input[disabled]) input::placeholder,
+.emotion-6:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-6:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -207,6 +227,7 @@ exports[`<Form /> component renders simple form 1`] = `
       </label>
       <div
         class="emotion-6 emotion-7"
+        data-testid="input-wrapper"
       >
         <input
           class="emotion-8 emotion-9"
@@ -231,6 +252,7 @@ exports[`<Form /> component renders simple form 1`] = `
       </label>
       <div
         class="emotion-6 emotion-7"
+        data-testid="input-wrapper"
       >
         <input
           class="emotion-8 emotion-9"
@@ -382,62 +404,82 @@ exports[`<Form /> component with Form.Group should render a disabled form group 
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-10:has(input:focus) {
-  border-color: #000000;
+.emotion-10:focus-within,
+.emotion-10:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-10:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-10:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-10:has(input[readonly]:not([disabled])) {
+.emotion-10:focus-within:has(input[readonly]:not([disabled])),
+.emotion-10:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-10:has(input[disabled]),
-.emotion-10:has(input[disabled])>* {
+.emotion-10:focus-within:has(input[disabled]),
+.emotion-10:hover:has(input[disabled]),
+.emotion-10:focus-within:has(input[disabled])>*,
+.emotion-10:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-10:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input::-moz-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-10:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input::-moz-placeholder {
+.emotion-10:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-10:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input::placeholder,
-.emotion-10:has(input[disabled])>* input::placeholder {
+.emotion-10:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled]) input::placeholder,
+.emotion-10:hover:has(input[disabled]) input::placeholder,
+.emotion-10:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-10:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -503,6 +545,7 @@ exports[`<Form /> component with Form.Group should render a disabled form group 
           </label>
           <div
             class="emotion-10 emotion-11"
+            data-testid="input-wrapper"
           >
             <input
               class="emotion-12 emotion-13"
@@ -654,62 +697,82 @@ exports[`<Form /> component with Form.Group should render a form with display fl
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-10:has(input:focus) {
-  border-color: #000000;
+.emotion-10:focus-within,
+.emotion-10:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-10:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-10:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-10:has(input[readonly]:not([disabled])) {
+.emotion-10:focus-within:has(input[readonly]:not([disabled])),
+.emotion-10:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-10:has(input[disabled]),
-.emotion-10:has(input[disabled])>* {
+.emotion-10:focus-within:has(input[disabled]),
+.emotion-10:hover:has(input[disabled]),
+.emotion-10:focus-within:has(input[disabled])>*,
+.emotion-10:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-10:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input::-moz-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-10:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-10:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input::-moz-placeholder {
+.emotion-10:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-10:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-10:has(input[disabled]) input::placeholder,
-.emotion-10:has(input[disabled])>* input::placeholder {
+.emotion-10:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-10:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-10:focus-within:has(input[disabled]) input::placeholder,
+.emotion-10:hover:has(input[disabled]) input::placeholder,
+.emotion-10:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-10:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -774,6 +837,7 @@ exports[`<Form /> component with Form.Group should render a form with display fl
           </label>
           <div
             class="emotion-10 emotion-11"
+            data-testid="input-wrapper"
           >
             <input
               class="emotion-12 emotion-13"
@@ -798,6 +862,7 @@ exports[`<Form /> component with Form.Group should render a form with display fl
           </label>
           <div
             class="emotion-10 emotion-11"
+            data-testid="input-wrapper"
           >
             <input
               class="emotion-12 emotion-13"
@@ -975,62 +1040,82 @@ exports[`<Form /> component with Form.Group should render a form with group titl
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-14:has(input:focus) {
-  border-color: #000000;
+.emotion-14:focus-within,
+.emotion-14:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-14:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-14:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-14:has(input[readonly]:not([disabled])) {
+.emotion-14:focus-within:has(input[readonly]:not([disabled])),
+.emotion-14:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-14:has(input[disabled]),
-.emotion-14:has(input[disabled])>* {
+.emotion-14:focus-within:has(input[disabled]),
+.emotion-14:hover:has(input[disabled]),
+.emotion-14:focus-within:has(input[disabled])>*,
+.emotion-14:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-14:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-14:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled]) input::-moz-placeholder {
+.emotion-14:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-14:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-14:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled])>* input::-moz-placeholder {
+.emotion-14:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-14:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-14:has(input[disabled]) input::placeholder,
-.emotion-14:has(input[disabled])>* input::placeholder {
+.emotion-14:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-14:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-14:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-14:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-14:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-14:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-14:focus-within:has(input[disabled]) input::placeholder,
+.emotion-14:hover:has(input[disabled]) input::placeholder,
+.emotion-14:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-14:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -1107,6 +1192,7 @@ exports[`<Form /> component with Form.Group should render a form with group titl
           </label>
           <div
             class="emotion-14 emotion-15"
+            data-testid="input-wrapper"
           >
             <input
               class="emotion-16 emotion-17"
@@ -1131,6 +1217,7 @@ exports[`<Form /> component with Form.Group should render a form with group titl
           </label>
           <div
             class="emotion-14 emotion-15"
+            data-testid="input-wrapper"
           >
             <input
               class="emotion-16 emotion-17"

--- a/packages/react-packages/text-field/src/TextField.styled.ts
+++ b/packages/react-packages/text-field/src/TextField.styled.ts
@@ -15,6 +15,7 @@ export interface InputWrapperStyledProps {
   isFloatingLabel: boolean;
   variant: TextFieldVariant;
   backgroundFill: TextFieldBackgroundFill;
+  hasError: boolean;
 }
 
 export const TextFieldStyled = styled.div<{
@@ -156,7 +157,16 @@ export const ResetInputIconStyled = styled.div`
 `;
 
 export const InputWrapperStyled = styled.div<InputWrapperStyledProps>`
-  ${({ theme, isFloatingLabel, variant, backgroundFill }) => `
+  ${({ theme, isFloatingLabel, variant, backgroundFill, hasError }) => {
+    const borderColor = hasError
+      ? theme.palette.error.default
+      : theme.palette.border.medium;
+
+    const borderFocusColor = hasError
+      ? theme.palette.error.default
+      : theme.palette.border.dark;
+
+    return `
     display:flex;
     flex-direction: row;
     align-items: center;
@@ -169,26 +179,17 @@ export const InputWrapperStyled = styled.div<InputWrapperStyledProps>`
     
     padding-inline: ${theme.spacing['3xs']};
 
-    border-radius: ${
+    ${
       variant === 'outlined'
-        ? theme.shape.formField
-        : `${theme.shape.formField} ${theme.shape.formField} 0 0`
+        ? `border-radius: ${theme.shape.formField};
+            border: 1px solid ${borderColor};
+            &:focus-within, &:hover { { border: 1px solid ${borderFocusColor}};
+          `
+        : `border-radius: ${theme.shape.formField} ${theme.shape.formField} 0 0;
+            border-bottom: 1px solid ${borderColor};
+            &:focus-within, &:hover { { border-bottom: 1px solid  ${borderFocusColor}};
+          `
     };
-    border-style: solid;
-    ${variant === 'outlined' ? 'border-width: 1px' : 'border-width: 0 0 1px'};
-    border-color: ${theme.palette.border.medium};
-
-    &:has(input:focus) {
-      border-color: ${theme.palette.primary.default};
-    }
-
-    &:has(input[data-error="true"]) {
-      border-color: ${theme.palette.error.default};
-
-      &:focus {
-        border-color: ${theme.palette.error.default};
-      }
-    }
 
     &:has(input[readonly]:not([disabled])) {
       background-color: ${theme.palette.surface.default};
@@ -205,5 +206,6 @@ export const InputWrapperStyled = styled.div<InputWrapperStyledProps>`
         color: ${isFloatingLabel ? 'transparent' : theme.palette.content.light};
       }
     }
-  `}
+  `;
+  }}
 `;

--- a/packages/react-packages/text-field/src/TextField.test.tsx
+++ b/packages/react-packages/text-field/src/TextField.test.tsx
@@ -123,12 +123,25 @@ describe('<TextField /> component', () => {
 
     const input = screen.getByRole('textbox');
     const label = screen.getByTestId('label-field');
+    const inputWrapper = screen.getByTestId('input-wrapper');
 
     fireEvent.focus(input);
 
     expect(label).toHaveStyle('font-size: 0.75rem');
     expect(label).toHaveStyle('transform: translateY(-45%)');
     expect(input).toHaveStyle('outline: 0;');
+    expect(inputWrapper).toHaveStyle('border-width: 1px;');
+    expect(inputWrapper).toHaveStyle('border-style: solid');
+  });
+
+  it('should have hover style', () => {
+    render(<ProvidedTextField label='Some text' />);
+
+    const inputWrapper = screen.getByTestId('input-wrapper');
+
+    fireEvent.mouseOver(inputWrapper, { currentTarget: { value: '' } });
+
+    expect(inputWrapper).toHaveStyle('border: 1px solid #131313;');
   });
 
   describe('onBlur event', () => {
@@ -231,7 +244,6 @@ describe('<TextField /> component', () => {
   });
 
   test('should call onClick when extra suffix is clicked', () => {
-    const ProvidedTextField = withProviders(TextField);
     const handleClick = jest.fn();
 
     render(
@@ -257,7 +269,6 @@ describe('<TextField /> component', () => {
   });
 
   test('should call onClick when extra preffix is clicked', () => {
-    const ProvidedTextField = withProviders(TextField);
     const handleClick = jest.fn();
 
     render(
@@ -283,7 +294,6 @@ describe('<TextField /> component', () => {
   });
 
   test('should clear input after reset icon clicked', () => {
-    const ProvidedTextField = withProviders(TextField);
     const handleClick = jest.fn();
 
     render(

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -175,6 +175,8 @@ export const TextField = ({
 
       <InputWrapperStyled
         backgroundFill={backgroundFill}
+        data-testid='input-wrapper'
+        hasError={showError}
         isFloatingLabel={isFloatingLabel}
         variant={variant}
       >

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -81,62 +81,82 @@ exports[`<TextField /> component renders disabled input 1`] = `
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -192,6 +212,7 @@ exports[`<TextField /> component renders disabled input 1`] = `
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -294,62 +315,82 @@ exports[`<TextField /> component renders input with extras suffix and prefix ele
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -439,6 +480,7 @@ exports[`<TextField /> component renders input with extras suffix and prefix ele
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <div
         class="emotion-6 emotion-7"
@@ -559,62 +601,82 @@ exports[`<TextField /> component renders input with light background fill 1`] = 
   background-color: #FAFAFA;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -669,6 +731,7 @@ exports[`<TextField /> component renders input with light background fill 1`] = 
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -765,62 +828,82 @@ exports[`<TextField /> component renders input with variant baseLine 1`] = `
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px 0px 0 0;
-  border-style: solid;
-  border-width: 0 0 1px;
-  border-color: #C1C1C1;
+  border-bottom: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border-bottom: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -875,6 +958,7 @@ exports[`<TextField /> component renders input with variant baseLine 1`] = `
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -956,62 +1040,82 @@ exports[`<TextField /> component renders input without floating label 1`] = `
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: #A3A3A3;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: #A3A3A3;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: #A3A3A3;
 }
 
@@ -1065,6 +1169,7 @@ exports[`<TextField /> component renders input without floating label 1`] = `
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -1161,62 +1266,82 @@ exports[`<TextField /> component should render the TextField with error styles a
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #A00000;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -1285,6 +1410,7 @@ exports[`<TextField /> component should render the TextField with error styles a
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"
@@ -1392,62 +1518,82 @@ exports[`<TextField /> component should render the TextField with info message 1
   background-color: #F3F3F5;
   padding-inline: 12px;
   border-radius: 0px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: #C1C1C1;
+  border: 1px solid #C1C1C1;
 }
 
-.emotion-4:has(input:focus) {
-  border-color: #000000;
+.emotion-4:focus-within,
+.emotion-4:hover {
+  border: 1px solid #131313;
 }
 
-.emotion-4:has(input[data-error="true"]) {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[data-error="true"]):focus {
-  border-color: #A00000;
-}
-
-.emotion-4:has(input[readonly]:not([disabled])) {
+.emotion-4:focus-within:has(input[readonly]:not([disabled])),
+.emotion-4:hover:has(input[readonly]:not([disabled])) {
   background-color: #F3F3F5;
   color: #838383;
 }
 
-.emotion-4:has(input[disabled]),
-.emotion-4:has(input[disabled])>* {
+.emotion-4:focus-within:has(input[disabled]),
+.emotion-4:hover:has(input[disabled]),
+.emotion-4:focus-within:has(input[disabled])>*,
+.emotion-4:hover:has(input[disabled])>* {
   color: #A3A3A3;
   background-color: #FAFAFA;
   border-color: #DEDEDE;
   cursor: not-allowed;
 }
 
-.emotion-4:has(input[disabled]) input::-webkit-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::-moz-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input:-ms-input-placeholder {
+.emotion-4:focus-within:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-webkit-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-webkit-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input::-moz-placeholder {
+.emotion-4:hover:has(input[disabled]) input::-moz-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled])>* input:-ms-input-placeholder {
+.emotion-4:hover:has(input[disabled]) input:-ms-input-placeholder {
   color: transparent;
 }
 
-.emotion-4:has(input[disabled]) input::placeholder,
-.emotion-4:has(input[disabled])>* input::placeholder {
+.emotion-4:focus-within:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-4:hover:has(input[disabled])>* input:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-4:focus-within:has(input[disabled]) input::placeholder,
+.emotion-4:hover:has(input[disabled]) input::placeholder,
+.emotion-4:focus-within:has(input[disabled])>* input::placeholder,
+.emotion-4:hover:has(input[disabled])>* input::placeholder {
   color: transparent;
 }
 
@@ -1516,6 +1662,7 @@ exports[`<TextField /> component should render the TextField with info message 1
     </label>
     <div
       class="emotion-4 emotion-5"
+      data-testid="input-wrapper"
     >
       <input
         class="emotion-6 emotion-7"


### PR DESCRIPTION
## Description

Adding text field hover and focus effects according to [design](https://www.figma.com/design/kMk36nv0ZT4AHhBbw9jq0S/%E2%86%B3-1.-Daimler-Truck-DDS--Beta-?node-id=8913-60394&t=KJoIEnLXMTnRIkol-0) 
## Issue

[ITCAPI-6215](https://jir.t3.daimlertruck.com/browse/ITCAPI-6215)

## Screenshots
![222222](https://github.com/user-attachments/assets/8982034d-7762-457a-a00b-fdd1db8f36dc)



## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/daimlertruck/dt-ui/PR-14