### PR TITLE
Refactor: Drop icon funcional state

### DIFF
--- a/packages/react-packages/dropdown/package.json
+++ b/packages/react-packages/dropdown/package.json
@@ -21,9 +21,10 @@
   },
   "dependencies": {
     "@dt-ui/react-box": "0.1.0-beta.8",
-    "@dt-ui/react-core": "0.1.0-beta.40",
-    "@dt-ui/react-icon": "0.1.0-beta.40",
-    "@dt-ui/react-typography": "0.1.0-beta.31"
+    "@dt-ui/react-core": "0.1.0-beta.39",
+    "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
+    "@dt-ui/react-typography": "0.1.0-beta.30"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",

--- a/packages/react-packages/dropdown/src/components/select/DropdownSelect.tsx
+++ b/packages/react-packages/dropdown/src/components/select/DropdownSelect.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@dt-ui/react-box';
 import { BaseProps } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { Typography } from '@dt-ui/react-typography';
 import { useTheme } from '@emotion/react';
 import { Children, ReactElement, useEffect } from 'react';
@@ -124,13 +125,14 @@ export const DropdownSelect = ({
         </div>
         <Box style={{ flexDirection: 'row', gap: '0.5rem' }}>
           {hasDeselect && !!state.value ? (
-            <Icon
-              code='close'
-              color={disabledIconColor}
-              dataTestId='deselect-value'
-              onClick={handleDeselectClick}
-              size='s'
-            />
+            <IconButton onClick={handleDeselectClick}>
+              <Icon
+                code='close'
+                color={disabledIconColor}
+                dataTestId='deselect-value'
+                size='s'
+              />
+            </IconButton>
           ) : null}
           <Icon
             code={isOpen ? 'expand_less' : 'expand_more'}

--- a/packages/react-packages/icon/src/Icon.styled.ts
+++ b/packages/react-packages/icon/src/Icon.styled.ts
@@ -6,7 +6,6 @@ interface IconStyledProps {
   color: string;
   size: Size;
   variant: Variant;
-  hasClick: boolean;
 }
 
 export const fontSize: Record<Size, string> = {
@@ -18,7 +17,7 @@ export const fontSize: Record<Size, string> = {
 };
 
 export const IconStyled = styled.i<IconStyledProps>`
-  ${({ size, theme, variant, color, hasClick }) => `
+  ${({ size, theme, variant, color }) => `
     font-family: DTUI-icons-${theme.icons};
     font-weight: normal;
     font-style: normal;
@@ -42,13 +41,5 @@ export const IconStyled = styled.i<IconStyledProps>`
   
     /* Support for IE. */
     font-feature-settings: 'liga';
-
-    ${
-      hasClick &&
-      `
-        cursor: pointer;
-        user-select: none;
-      `
-    };
   `}
 `;

--- a/packages/react-packages/icon/src/Icon.test.tsx
+++ b/packages/react-packages/icon/src/Icon.test.tsx
@@ -16,7 +16,8 @@ describe('Icon component tests', () => {
   it('applies the specified color in the Icon component', () => {
     const { container } = render(<ProvidedIcon code={CODE} color='red' />);
 
-    expect(container.querySelector('i')).toHaveStyle('color: red');
+    const iconElement = container.querySelector('i');
+    expect(iconElement).toHaveStyleRule('color', 'red');
   });
 
   it.each`

--- a/packages/react-packages/icon/src/Icon.tsx
+++ b/packages/react-packages/icon/src/Icon.tsx
@@ -10,7 +10,6 @@ export interface IconProps extends Omit<BaseProps, 'children'> {
   color?: string;
   size?: Size;
   variant?: Variant;
-  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 export const Icon = ({
@@ -20,7 +19,6 @@ export const Icon = ({
   size = 'l',
   style,
   variant = 'outlined',
-  onClick,
 }: IconProps) => {
   const theme = useTheme();
 
@@ -28,8 +26,6 @@ export const Icon = ({
     <IconStyled
       color={color ?? theme.palette.content.default}
       data-testid={dataTestId ?? 'icon'}
-      hasClick={!!onClick}
-      onClick={onClick}
       size={size}
       style={style}
       variant={variant}

--- a/packages/react-packages/select/package.json
+++ b/packages/react-packages/select/package.json
@@ -20,12 +20,13 @@
     "test:update:snapshot": "jest -u"
   },
   "dependencies": {
-    "@dt-ui/react-checkbox": "0.1.0-beta.38",
-    "@dt-ui/react-core": "0.1.0-beta.40",
-    "@dt-ui/react-icon": "0.1.0-beta.40",
-    "@dt-ui/react-label-field": "0.1.0-beta.36",
-    "@dt-ui/react-tooltip": "0.1.0-beta.48",
-    "@dt-ui/react-typography": "0.1.0-beta.31",
+    "@dt-ui/react-checkbox": "0.1.0-beta.37",
+    "@dt-ui/react-core": "0.1.0-beta.39",
+    "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
+    "@dt-ui/react-label-field": "0.1.0-beta.35",
+    "@dt-ui/react-tooltip": "0.1.0-beta.47",
+    "@dt-ui/react-typography": "0.1.0-beta.30",
     "downshift": "^9.0.4"
   },
   "devDependencies": {

--- a/packages/react-packages/select/src/Select.tsx
+++ b/packages/react-packages/select/src/Select.tsx
@@ -1,5 +1,6 @@
 import { BaseProps, useClickOutside } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { LabelField } from '@dt-ui/react-label-field';
 import { Tooltip } from '@dt-ui/react-tooltip';
 import { Typography } from '@dt-ui/react-typography';
@@ -272,12 +273,9 @@ const Select = ({
             <SelectActionContainerStyled>
               {isMulti && hasSelectedItems ? (
                 <Tooltip>
-                  <Icon
-                    code='close'
-                    dataTestId='clear-selection'
-                    onClick={clearSelection}
-                    size='s'
-                  />
+                  <IconButton onClick={clearSelection}>
+                    <Icon code='close' dataTestId='clear-selection' size='s' />
+                  </IconButton>
                   <Tooltip.Content>Clear all</Tooltip.Content>
                 </Tooltip>
               ) : null}

--- a/packages/react-packages/tabs/package.json
+++ b/packages/react-packages/tabs/package.json
@@ -20,8 +20,9 @@
     "test:update:snapshot": "jest -u"
   },
   "dependencies": {
-    "@dt-ui/react-core": "0.1.0-beta.40",
-    "@dt-ui/react-icon": "0.1.0-beta.40",
+    "@dt-ui/react-core": "0.1.0-beta.39",
+    "@dt-ui/react-icon": "0.1.0-beta.39",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
     "@dt-ui/react-box": "0.1.0-beta.8"
   },
   "devDependencies": {

--- a/packages/react-packages/tabs/src/Tabs.tsx
+++ b/packages/react-packages/tabs/src/Tabs.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@dt-ui/react-box';
 import { BaseProps, useDebounceResize } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { useTheme } from '@emotion/react';
 import {
   Children,
@@ -93,16 +94,13 @@ export const Tabs = ({
         }),
       }}
     >
-      <Icon
-        code='keyboard_arrow_left'
-        dataTestId='left-arrow'
-        onClick={() => handleScroll(-SCROLL_MOVEMENT)}
-        style={{
-          ...(!isLeftSideOverflowing && {
-            display: 'none',
-          }),
-        }}
-      />
+      <IconButton onClick={() => handleScroll(-SCROLL_MOVEMENT)}>
+        <Icon
+          code='keyboard_arrow_left'
+          dataTestId='left-arrow'
+          style={{ ...(!isLeftSideOverflowing && { display: 'none' }) }}
+        />
+      </IconButton>
       <TabsStyled
         data-testid={dataTestId}
         ref={ref}
@@ -112,16 +110,13 @@ export const Tabs = ({
       >
         {clonedChildren}
       </TabsStyled>
-      <Icon
-        code='keyboard_arrow_right'
-        dataTestId='right-arrow'
-        onClick={() => handleScroll(SCROLL_MOVEMENT)}
-        style={{
-          ...(!isRightSideOverflowing && {
-            display: 'none',
-          }),
-        }}
-      />
+      <IconButton onClick={() => handleScroll(SCROLL_MOVEMENT)}>
+        <Icon
+          code='keyboard_arrow_right'
+          dataTestId='right-arrow'
+          style={{ ...(!isRightSideOverflowing && { display: 'none' }) }}
+        />
+      </IconButton>
     </Box>
   );
 };

--- a/packages/react-packages/tabs/src/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-packages/tabs/src/__snapshots__/Tabs.test.tsx.snap
@@ -16,6 +16,34 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.emotion-2 i {
+  font-size: 24px;
+  color: #292929;
+}
+
+.emotion-2:not(:disabled)>i:hover,
+.emotion-2:not(:disabled)>i:active {
+  color: #00677F;
+}
+
+.emotion-2:focus-visible {
+  outline: 2px solid #000000;
+}
+
+.emotion-4 {
   font-family: DTUI-icons-outlined;
   font-weight: normal;
   font-style: normal;
@@ -32,14 +60,9 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 }
 
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -51,7 +74,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   width: 100%;
 }
 
-.emotion-6 {
+.emotion-8 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,7 +98,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   gap: 8px;
 }
 
-.emotion-8 {
+.emotion-10 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -99,30 +122,11 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
   gap: 8px;
 }
 
-.emotion-8:hover {
+.emotion-10:hover {
   background-color: #CCE3EB;
 }
 
-.emotion-12 {
-  font-family: DTUI-icons-outlined;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  font-variation-settings: 'FILL' 0;
-  color: #292929;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
-}
-
-.emotion-14 {
+.emotion-16 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -151,21 +155,26 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
     class="emotion-0 emotion-1"
     style="flex-direction: row;"
   >
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="left-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_left
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="left-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_left
+      </i>
+    </button>
     <div
-      class="emotion-4 emotion-5"
+      class="emotion-6 emotion-7"
       data-testid="tabs"
       role="tablist"
     >
       <button
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="tab-item-0"
         role="tab"
         tabindex="0"
@@ -173,7 +182,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 1
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-1"
         role="tab"
         tabindex="-1"
@@ -181,13 +190,13 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 2
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-2"
         role="tab"
         tabindex="-1"
       >
         <i
-          class="emotion-12 emotion-3"
+          class="emotion-4 emotion-5"
           color="#292929"
           data-testid="icon"
         >
@@ -196,7 +205,7 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 3
       </button>
       <button
-        class="emotion-14 emotion-7"
+        class="emotion-16 emotion-9"
         data-testid="tab-item-3"
         disabled=""
         role="tab"
@@ -205,14 +214,19 @@ exports[`<Tabs /> component should match the snapshot by displaying contained va
         Tab 4
       </button>
     </div>
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="right-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_right
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="right-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_right
+      </i>
+    </button>
   </div>
 </div>
 `;
@@ -233,6 +247,34 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.emotion-2 i {
+  font-size: 24px;
+  color: #292929;
+}
+
+.emotion-2:not(:disabled)>i:hover,
+.emotion-2:not(:disabled)>i:active {
+  color: #00677F;
+}
+
+.emotion-2:focus-visible {
+  outline: 2px solid #000000;
+}
+
+.emotion-4 {
   font-family: DTUI-icons-outlined;
   font-weight: normal;
   font-style: normal;
@@ -249,14 +291,9 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 }
 
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -269,7 +306,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   margin-bottom: -1px;
 }
 
-.emotion-6 {
+.emotion-8 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -294,7 +331,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   gap: 8px;
 }
 
-.emotion-8 {
+.emotion-10 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -318,30 +355,11 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
   gap: 8px;
 }
 
-.emotion-8:hover {
+.emotion-10:hover {
   background-color: #CCE3EB;
 }
 
-.emotion-12 {
-  font-family: DTUI-icons-outlined;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  font-variation-settings: 'FILL' 0;
-  color: #292929;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
-}
-
-.emotion-14 {
+.emotion-16 {
   border: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -370,21 +388,26 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
     class="emotion-0 emotion-1"
     style="flex-direction: row; border-bottom: 1px solid #DEDEDE;"
   >
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="left-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_left
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="left-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_left
+      </i>
+    </button>
     <div
-      class="emotion-4 emotion-5"
+      class="emotion-6 emotion-7"
       data-testid="tabs"
       role="tablist"
     >
       <button
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="tab-item-0"
         role="tab"
         tabindex="0"
@@ -392,7 +415,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 1
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-1"
         role="tab"
         tabindex="-1"
@@ -400,13 +423,13 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 2
       </button>
       <button
-        class="emotion-8 emotion-7"
+        class="emotion-10 emotion-9"
         data-testid="tab-item-2"
         role="tab"
         tabindex="-1"
       >
         <i
-          class="emotion-12 emotion-3"
+          class="emotion-4 emotion-5"
           color="#292929"
           data-testid="icon"
         >
@@ -415,7 +438,7 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 3
       </button>
       <button
-        class="emotion-14 emotion-7"
+        class="emotion-16 emotion-9"
         data-testid="tab-item-3"
         disabled=""
         role="tab"
@@ -424,14 +447,19 @@ exports[`<Tabs /> component should match the snapshot by displaying default vari
         Tab 4
       </button>
     </div>
-    <i
+    <button
       class="emotion-2 emotion-3"
-      color="#292929"
-      data-testid="right-arrow"
-      style="display: none;"
+      data-testid="icon-button"
     >
-      keyboard_arrow_right
-    </i>
+      <i
+        class="emotion-4 emotion-5"
+        color="#292929"
+        data-testid="right-arrow"
+        style="display: none;"
+      >
+        keyboard_arrow_right
+      </i>
+    </button>
   </div>
 </div>
 `;

--- a/packages/react-packages/text-field/package.json
+++ b/packages/react-packages/text-field/package.json
@@ -20,11 +20,12 @@
     "test:update:snapshot": "jest -u"
   },
   "dependencies": {
-    "@dt-ui/react-core": "0.1.0-beta.40",
-    "@dt-ui/react-spinner": "0.1.0-beta.42",
-    "@dt-ui/react-label-field": "0.1.0-beta.36",
-    "@dt-ui/react-typography": "0.1.0-beta.31",
-    "@dt-ui/react-icon": "0.1.0-beta.40"
+    "@dt-ui/react-core": "0.1.0-beta.39",
+    "@dt-ui/react-spinner": "0.1.0-beta.41",
+    "@dt-ui/react-label-field": "0.1.0-beta.35",
+    "@dt-ui/react-typography": "0.1.0-beta.30",
+    "@dt-ui/react-icon-button": "0.1.0-beta.7",
+    "@dt-ui/react-icon": "0.1.0-beta.39"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",

--- a/packages/react-packages/text-field/src/TextField.stories.tsx
+++ b/packages/react-packages/text-field/src/TextField.stories.tsx
@@ -23,11 +23,11 @@ type TextFieldPropsWithExtrasProp = TextFieldProps & {
 };
 
 const extraPrefix: ExtraComponent = {
-  component: <Icon code='home_work' size='large' />,
+  component: <Icon code='home_work' size='l' />,
 };
 
 const extraSuffix: ExtraComponent = {
-  component: <Icon code='home_work' size='large' />,
+  component: <Icon code='home_work' size='l' />,
 };
 
 const meta: Meta<TextFieldPropsWithExtrasProp> = {

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -1,5 +1,6 @@
 import { BaseProps } from '@dt-ui/react-core';
 import { Icon } from '@dt-ui/react-icon';
+import { IconButton } from '@dt-ui/react-icon-button';
 import { LabelField } from '@dt-ui/react-label-field';
 import { Typography } from '@dt-ui/react-typography';
 import {
@@ -216,7 +217,9 @@ export const TextField = ({
             onKeyDown={handleResetIconEnter}
             tabIndex={0}
           >
-            <Icon code='close_small' onClick={handleResetInput} />
+            <IconButton onClick={handleResetInput}>
+              <Icon code='close_small' />
+            </IconButton>
           </ResetInputIconStyled>
         ) : null}
 


### PR DESCRIPTION
## Description

The Icon component is purely presentational and not interactive therefore it should not have the onclick prop. The semantic `<i>` element isn't meant for interactions.

Icon interaction and states must be handled by `IconButton` 

## Issue

NA

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/daimlertruck/dt-ui/PR-17

https://daimlertruck.github.io/dt-ui/PR-17