### PR TITLE
chore: fix publish config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,5 +151,7 @@ jobs:
           PACKAGE_FILE="${PACKAGE_FILE_NAME}-v${PACKAGE_VERSION}.tgz"
 
           # Publish from root directory
-          npm publish "${{ steps.package-detail.outputs.directory }}/$PACKAGE_FILE" --access public
+          # with force to handle deleted versions
+          # remove flag in ~48h
+          npm publish "${{ steps.package-detail.outputs.directory }}/$PACKAGE_FILE" --access public --force
           rm -f "${{ steps.package-detail.outputs.directory }}/$PACKAGE_FILE"


### PR DESCRIPTION
## Description

Bug fix:
* add force flag
* npmjs.org keeps record of deleted versions  for ~48h preventing the publish

<!-- Provide a detailed description about the nature of your PR and what it solves -->

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->