### PR TITLE
chore: fix react-box pkg publish by bumping version

### DIFF
--- a/.changeset/tough-chairs-brake.md
+++ b/.changeset/tough-chairs-brake.md
@@ -1,0 +1,5 @@
+---
+'@dt-dds/react-box': patch
+---
+
+fix pkg publish by bumping version after npmjs.org unpublish


### PR DESCRIPTION
## Description

Force version bump on react-box to bug fix broken publish: 

* npmjs.org keeps immutable registry data
* even if the pkg is unpublished
* no same version can be published


<!-- Provide a detailed description about the nature of your PR and what it solves -->

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->