### PR TITLE
fix: use gh App token for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,10 +165,18 @@ jobs:
     needs: [publish]
     if: always() && needs.publish.result == 'success'
     steps:
+      - name: Generate CI_BOT Token
+        id: ci-bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_BOT_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ steps.ci-bot-token.outputs.token }}
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'
@@ -186,6 +194,4 @@ jobs:
           git config --global user.name ${{ env.GIT_FAKE_USER }}
           git add README.md
           git diff --staged --quiet || git commit -m "docs: update pkgs list in README [skip ci]"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git push origin ${{ github.ref }}


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->

Only the CI Bot can bypass the main protection rules.
This PR fixes the bug from https://github.com/daimlertruck/DT-DDS/actions/runs/17249152556/job/48946988094#step:5:30

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
