### PR TITLE
fix: button-responsiveness

### DIFF
--- a/packages/react-packages/button/src/Button.styled.ts
+++ b/packages/react-packages/button/src/Button.styled.ts
@@ -42,7 +42,7 @@ export const ButtonStyled = styled.button<ButtonStyledProps>`
       }
     }
 
-    @media only screen and (max-width: ${theme.breakpoints.mq2}px) {
+    @media only screen and (max-width: ${theme.breakpoints.mq3}px) {
       width: 100%;
     }
   `};

--- a/packages/react-packages/button/src/Button.test.tsx
+++ b/packages/react-packages/button/src/Button.test.tsx
@@ -107,7 +107,7 @@ describe('<Button /> component', () => {
     );
 
     expect(container.firstChild).toHaveStyleRule('width', '100%', {
-      media: '(max-width: 480px)',
+      media: `(max-width: ${theme.breakpoints.mq3}px)`,
     });
   });
 });

--- a/packages/react-packages/button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-packages/button/src/__snapshots__/Button.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`<Button /> component renders button html element with the correct title
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 100%;
   }
@@ -157,7 +157,7 @@ exports[`<Button /> component when loading is true renders a spinner dark theme 
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 100%;
   }
@@ -274,7 +274,7 @@ exports[`<Button /> component when loading is true renders a spinner light theme
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-0 {
     width: 100%;
   }

--- a/packages/react-packages/empty-state/src/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-packages/empty-state/src/__snapshots__/EmptyState.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`<EmptyState /> component should render Empty State with a Button 1`] = 
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-6 {
     width: 100%;
   }

--- a/packages/react-packages/modal/src/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-packages/modal/src/__snapshots__/Modal.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`<Modal/> Component handle modal actions renders modal correctly 1`] = `
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-14 {
     width: 100%;
   }
@@ -613,7 +613,7 @@ exports[`<Modal/> Component handle modal actions renders modal correctly 1`] = `
   outline-offset: 1px;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and (max-width: 768px) {
   .emotion-15 {
     width: 100%;
   }


### PR DESCRIPTION

## Description

In viewports smaller than tablet the button should expand the full width of the container.

## Issue

NA

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-40