### PR TITLE
feat: allow passing icon to text area label

### DIFF
--- a/packages/react-packages/text-area/README.md
+++ b/packages/react-packages/text-area/README.md
@@ -29,6 +29,7 @@ export const App = () => {
 | `message`        | `string`                    | -                | The message to be displayed below the input field. Useful for hints or to display errors. |
 | `labelVariant`   | `[default, floating]`       | `default`        | Sets the label floating or traditional on top of the input                                |
 | `hasLabel`       | `boolean`                   | `true`           | Show/hide the label                                                                       |
+| `labelIcon`      | `ReactNode`.      | -                | Sets an element for label to provide guidance about the scope of the field.                     |
 
 ## Stack
 

--- a/packages/react-packages/text-area/package.json
+++ b/packages/react-packages/text-area/package.json
@@ -24,6 +24,8 @@
     "@dt-dds/react-core": "1.0.0-beta.49",
     "@dt-dds/react-label-field": "1.0.0-beta.47",
     "@dt-dds/react-typography": "1.0.0-beta.40",
+    "@dt-dds/react-tooltip": "1.0.0-beta.57",
+    "@dt-dds/react-icon": "1.0.0-beta.50",
     "@dt-dds/themes": "1.0.0-beta.8"
   },
   "devDependencies": {

--- a/packages/react-packages/text-area/src/TextArea.stories.tsx
+++ b/packages/react-packages/text-area/src/TextArea.stories.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@dt-dds/react-icon';
+import { Tooltip } from '@dt-dds/react-tooltip';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { TextArea, TextAreaProps } from './TextArea';
@@ -59,5 +61,17 @@ export const Default: StoryObj<TextAreaProps> = {
     hasLabel: true,
     labelVariant: 'default',
     readOnly: false,
+  },
+};
+
+export const TestAreaWithLabelIcon: StoryObj<TextAreaProps> = {
+  args: {
+    label: 'My label',
+    labelIcon: (
+      <Tooltip>
+        <Icon code='info' size='s' />
+        <Tooltip.Content>Additional info about the field</Tooltip.Content>
+      </Tooltip>
+    ),
   },
 };

--- a/packages/react-packages/text-area/src/TextArea.test.tsx
+++ b/packages/react-packages/text-area/src/TextArea.test.tsx
@@ -1,4 +1,5 @@
 import { withProviders } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
 import { defaultTheme as theme } from '@dt-dds/themes';
 import { fireEvent, render, screen } from '@testing-library/react';
 
@@ -147,5 +148,174 @@ describe('<TextArea /> component', () => {
     expect(getByTestId('my-input-textarea')).toHaveStyle(
       `background-color: ${theme.palette.surface.light}`
     );
+  });
+
+  describe('TextArea labelIcon feature tests', () => {
+    test('renders label with icon', () => {
+      render(
+        <ProvidedTextArea
+          label='My textarea with icon'
+          labelIcon={<Icon code='info' size='s' />}
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toHaveTextContent('My textarea with icon');
+      expect(screen.getByTestId('icon')).toBeVisible();
+      expect(screen.getByTestId('icon')).toHaveTextContent('info');
+    });
+
+    test('renders label without icon when labelIcon prop is not provided', () => {
+      render(<ProvidedTextArea label='My textarea without icon' />);
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toBeVisible();
+      expect(label).toHaveTextContent('My textarea without icon');
+      expect(screen.queryByTestId('icon')).not.toBeInTheDocument();
+    });
+
+    test('renders label with icon and required indicator', () => {
+      render(
+        <ProvidedTextArea
+          label='My required textarea with icon'
+          labelIcon={<Icon code='warning' size='s' />}
+          required
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toHaveTextContent('My required textarea with icon*');
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    test('renders label with icon and maintains floating label behavior', () => {
+      render(
+        <ProvidedTextArea
+          label='My floating label with icon'
+          labelIcon={<Icon code='info' size='s' />}
+          labelVariant='floating'
+        />
+      );
+
+      const textarea = screen.getByRole('textbox');
+      const label = screen.getByTestId('label-field');
+
+      fireEvent.focus(textarea);
+
+      expect(label).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    test('renders label with icon and error state', () => {
+      render(
+        <ProvidedTextArea
+          hasError
+          label='My textarea with icon and error'
+          labelIcon={<Icon code='info' size='s' />}
+          message='Error message'
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+      expect(screen.getByText('Error message')).toBeVisible();
+    });
+
+    test('renders label with icon when hasLabel is true', () => {
+      render(
+        <ProvidedTextArea
+          hasLabel
+          label='Textarea with label and icon'
+          labelIcon={<Icon code='help' size='s' />}
+        />
+      );
+
+      expect(screen.getByTestId('label-field')).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    test('does not render icon when hasLabel is false', () => {
+      render(
+        <ProvidedTextArea
+          hasLabel={false}
+          label='Textarea without label'
+          labelIcon={<Icon code='help' size='s' />}
+        />
+      );
+
+      expect(screen.queryByTestId('label-field')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('icon')).not.toBeInTheDocument();
+    });
+
+    test('renders label with icon for default label variant', () => {
+      render(
+        <ProvidedTextArea
+          label='Default variant with icon'
+          labelIcon={<Icon code='info' size='s' />}
+          labelVariant='default'
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    test('renders label with icon when disabled', () => {
+      render(
+        <ProvidedTextArea
+          disabled
+          label='Disabled textarea with icon'
+          labelIcon={<Icon code='lock' size='s' />}
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    test('renders label with icon when readonly', () => {
+      render(
+        <ProvidedTextArea
+          label='Readonly textarea with icon'
+          labelIcon={<Icon code='visibility' size='s' />}
+          readOnly
+        />
+      );
+
+      const label = screen.getByTestId('label-field');
+      expect(label).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    test('renders label with icon and maxLength counter', () => {
+      render(
+        <ProvidedTextArea
+          label='Textarea with icon and counter'
+          labelIcon={<Icon code='edit' size='s' />}
+          maxLength={100}
+        />
+      );
+
+      expect(screen.getByTestId('label-field')).toBeVisible();
+      expect(screen.getByTestId('icon')).toBeVisible();
+      expect(screen.getByTestId('char-counter')).toHaveTextContent('0 / 100');
+    });
+
+    test('renders label with icon and updates on value change', () => {
+      render(
+        <ProvidedTextArea
+          label='Textarea with icon'
+          labelIcon={<Icon code='info' size='s' />}
+          value='Initial value'
+        />
+      );
+
+      expect(screen.getByTestId('icon')).toBeVisible();
+      expect(screen.getByRole('textbox')).toHaveValue('Initial value');
+    });
   });
 });

--- a/packages/react-packages/text-area/src/TextArea.tsx
+++ b/packages/react-packages/text-area/src/TextArea.tsx
@@ -7,6 +7,7 @@ import {
   ChangeEvent,
   ComponentPropsWithoutRef,
   FocusEvent,
+  ReactNode,
   useEffect,
   useState,
 } from 'react';
@@ -32,10 +33,12 @@ export interface TextAreaProps
   message?: string;
   labelVariant?: TextAreaLabelVariant;
   hasLabel?: boolean;
+  labelIcon?: ReactNode;
 }
 
 export const TextArea = ({
   label,
+  labelIcon,
   dataTestId,
   name,
   value,
@@ -117,6 +120,7 @@ export const TextArea = ({
         <LabelField
           hasError={showError}
           htmlFor={testId}
+          icon={labelIcon}
           isActive={isActive && !readOnly ? true : false}
           isDisabled={disabled || readOnly}
           isFloating={isFloatingLabel}


### PR DESCRIPTION
## Description

- Allow passing icon to text area label
## Issue

NA

## Screenshots
<img width="1114" height="331" alt="Screenshot 2025-10-15 at 14 15 57" src="https://github.com/user-attachments/assets/420eaa4c-a9c4-4ccf-8866-a56136fa89bc" />




## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-63