### PR TITLE
feat: add testId prop to text-field

### DIFF
--- a/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`<DatePicker /> component onBlur event should render error message when 
       <input
         class="emotion-3"
         data-error="true"
-        data-testid="input-field"
+        data-testid="choose-a-date-text-field"
         id="Choose-a-date"
         min="2023-03-30"
         name="Choose-a-date"
@@ -445,7 +445,7 @@ exports[`<DatePicker /> component onBlur event should render error message when 
       <input
         class="emotion-3"
         data-error="true"
-        data-testid="input-field"
+        data-testid="choose-a-date-text-field"
         id="Choose-a-date"
         max="2025-03-30"
         name="Choose-a-date"
@@ -682,7 +682,7 @@ exports[`<DatePicker /> component should render date input correctly 1`] = `
       <input
         class="emotion-4"
         data-error="false"
-        data-testid="input-field"
+        data-testid="choose-a-date-text-field"
         id="Choose-a-date"
         max="2025-03-30"
         min="2023-03-30"

--- a/packages/react-packages/form/src/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-packages/form/src/__snapshots__/Form.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`<Form /> component renders simple form 1`] = `
         <input
           class="emotion-5"
           data-error="false"
-          data-testid="input-field"
+          data-testid="label-1-text-field"
           id="label-1"
           name="label-1"
           type="text"
@@ -237,7 +237,7 @@ exports[`<Form /> component renders simple form 1`] = `
         <input
           class="emotion-5"
           data-error="false"
-          data-testid="input-field"
+          data-testid="label-2-text-field"
           id="label-2"
           name="label-2"
           type="text"
@@ -510,7 +510,7 @@ exports[`<Form /> component with Form.Group should render a disabled form group 
             <input
               class="emotion-9"
               data-error="false"
-              data-testid="input-field"
+              data-testid="label-1-text-field"
               id="label-1"
               name="label-1"
               type="text"
@@ -782,7 +782,7 @@ exports[`<Form /> component with Form.Group should render a form with display fl
             <input
               class="emotion-9"
               data-error="false"
-              data-testid="input-field"
+              data-testid="label-1-text-field"
               id="label-1"
               name="label-1"
               type="text"
@@ -807,7 +807,7 @@ exports[`<Form /> component with Form.Group should render a form with display fl
             <input
               class="emotion-9"
               data-error="false"
-              data-testid="input-field"
+              data-testid="label-2-text-field"
               id="label-2"
               name="label-2"
               type="text"
@@ -1118,7 +1118,7 @@ exports[`<Form /> component with Form.Group should render a form with group titl
             <input
               class="emotion-12"
               data-error="false"
-              data-testid="input-field"
+              data-testid="label-1-text-field"
               id="label-1"
               name="label-1"
               type="text"
@@ -1143,7 +1143,7 @@ exports[`<Form /> component with Form.Group should render a form with group titl
             <input
               class="emotion-12"
               data-error="false"
-              data-testid="input-field"
+              data-testid="label-2-text-field"
               id="label-2"
               name="label-2"
               type="text"

--- a/packages/react-packages/text-field/README.md
+++ b/packages/react-packages/text-field/README.md
@@ -38,6 +38,7 @@ export const App = () => {
 | `extraPrefix`     | `ExtraComponent`             | -          | Component to be rendered on the left side inside the input field                                      |
 | `extraSuffix`     | `ExtraComponent`             | -          | Component to be rendered on the right side inside the input field                                     |
 | `id`              | `string`                     | -          | The unique identifier used to link the element to the corresponding element via the htmlFor attribute |
+| `dataTestId`      | `string`                     | `label`-text-field | Customizable test identifier                                                                  |
 | `...`             | `InputHTMLAttributes`        | -          | All available attributes from native html input                                                       |
 
 ## Stack

--- a/packages/react-packages/text-field/src/TextField.test.tsx
+++ b/packages/react-packages/text-field/src/TextField.test.tsx
@@ -47,13 +47,18 @@ describe('<TextField /> component', () => {
       />
     );
 
-    expect(screen.getByTestId('input-field')).toHaveAttribute('id', 'my-id');
+    expect(
+      screen.getByTestId('my-input-with-prefilled-value-text-field')
+    ).toHaveAttribute('id', 'my-id');
   });
 
   it('renders input with a default id', () => {
     render(<ProvidedTextField initialValue='Initial Value' label='My Input' />);
 
-    expect(screen.getByTestId('input-field')).toHaveAttribute('id', 'my-input');
+    expect(screen.getByTestId('my-input-text-field')).toHaveAttribute(
+      'id',
+      'my-input'
+    );
   });
 
   it('fills input correctly with new value on change Event', () => {
@@ -99,7 +104,7 @@ describe('<TextField /> component', () => {
   it('renders hidden text input', () => {
     render(<ProvidedTextField label='Hidden text' type='password' />);
 
-    expect(screen.getByTestId('input-field')).toHaveAttribute(
+    expect(screen.getByTestId('hidden-text-text-field')).toHaveAttribute(
       'type',
       'password'
     );
@@ -168,7 +173,7 @@ describe('<TextField /> component', () => {
       render(
         <ProvidedTextField initialValue='Value' label='Some text' required />
       );
-      const input = screen.getByTestId('input-field');
+      const input = screen.getByTestId('some-text-text-field');
       const label = screen.getByTestId('label-field');
 
       fireEvent.blur(input, { currentTarget: { value: 'Some value' } });
@@ -260,7 +265,7 @@ describe('<TextField /> component', () => {
       />
     );
 
-    const input = screen.getByTestId('input-field');
+    const input = screen.getByTestId('search-for-anything-text-field');
 
     fireEvent.change(input, {
       target: { value: 'search' },
@@ -285,7 +290,7 @@ describe('<TextField /> component', () => {
       />
     );
 
-    const input = screen.getByTestId('input-field');
+    const input = screen.getByTestId('search-for-anything-text-field');
 
     fireEvent.change(input, {
       target: { value: 'search' },
@@ -311,7 +316,7 @@ describe('<TextField /> component', () => {
       />
     );
 
-    const input = screen.getByTestId('input-field');
+    const input = screen.getByTestId('search-for-anything-text-field');
 
     fireEvent.change(input, {
       target: { value: 'search' },

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -48,6 +48,7 @@ export interface TextFieldProps
 }
 
 export const TextField = ({
+  dataTestId,
   hasError = false,
   extraPrefix,
   extraSuffix,
@@ -75,6 +76,8 @@ export const TextField = ({
   const [inputValue, setInputValue] = useState('');
   const [hasRequiredError, setHasRequiredError] = useState(false);
   const textFieldId = id ?? label.replaceAll(' ', '-').toLowerCase();
+  const testId =
+    dataTestId ?? `${label.replaceAll(' ', '-').toLowerCase()}-text-field`;
 
   useEffect(() => {
     // Check if there's an initial value coming from props
@@ -199,7 +202,7 @@ export const TextField = ({
 
         <InputFieldStyled
           data-error={showError}
-          data-testid='input-field'
+          data-testid={testId}
           disabled={disabled}
           id={textFieldId}
           isFloatingLabel={isFloatingLabel}

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`<TextField /> component renders disabled input 1`] = `
       <input
         class="emotion-5 emotion-6"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-disabled-input-text-field"
         disabled=""
         id="my-disabled-input"
         name="my-disabled-input"
@@ -457,7 +457,7 @@ exports[`<TextField /> component renders input with extras suffix and prefix ele
       <input
         class="emotion-8 emotion-9"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-input-text-field"
         id="my-input"
         name="my-input"
         type="text"
@@ -676,7 +676,7 @@ exports[`<TextField /> component renders input with light background fill 1`] = 
       <input
         class="emotion-5 emotion-6"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-input-text-field"
         id="my-input"
         name="my-input"
         type="text"
@@ -879,7 +879,7 @@ exports[`<TextField /> component renders input with variant baseLine 1`] = `
       <input
         class="emotion-5 emotion-6"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-input-text-field"
         id="my-input"
         name="my-input"
         type="text"
@@ -1070,7 +1070,7 @@ exports[`<TextField /> component renders input without floating label 1`] = `
       <input
         class="emotion-5 emotion-6"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-input-text-field"
         id="my-input"
         name="my-input"
         type="text"
@@ -1292,7 +1292,7 @@ exports[`<TextField /> component should render the TextField with error styles a
       <input
         class="emotion-5 emotion-6"
         data-error="true"
-        data-testid="input-field"
+        data-testid="my-input-with-error-message-text-field"
         id="my-input-with-error-message"
         name="my-input-with-error-message"
         type="text"
@@ -1525,7 +1525,7 @@ exports[`<TextField /> component should render the TextField with info message 1
       <input
         class="emotion-5 emotion-6"
         data-error="false"
-        data-testid="input-field"
+        data-testid="my-input-with-info-message-text-field"
         id="my-input-with-info-message"
         name="my-input-with-info-message"
         type="text"


### PR DESCRIPTION
## Description

- add testId prop to text-field
## Issue

## Screenshots


<img width="537" height="66" alt="Screenshot 2025-10-16 at 09 39 54" src="https://github.com/user-attachments/assets/718a0ac6-e38b-461e-a4cf-e45627955f75" />

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-65