### PR TITLE
feat: persist avatar active state

### DIFF
--- a/packages/react-packages/avatar/README.md
+++ b/packages/react-packages/avatar/README.md
@@ -33,6 +33,7 @@ This component can contain upto two simple characters by passing a string in pro
 | `size`       | `enum<AvatarSize>` | medium  | Sets the Avatar size given the available options                   |
 | `imageSrc`   | `string`           | -       | Optional profile image path (will only work with "Profile" type)   |
 | `dataTestId` | `string`           | avatar  | Avatar test identifier                                             |
+| `isActive`   | `Boolean`          | false   | Persist the Avatar active state                                    |
 
 ## Stack
 

--- a/packages/react-packages/avatar/src/Avatar.stories.tsx
+++ b/packages/react-packages/avatar/src/Avatar.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta<typeof Avatar> = {
     hasTooltip: {
       control: { type: 'boolean' },
     },
+    isActive: {
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -33,6 +36,7 @@ export const Default: StoryObj<typeof Avatar> = {
     type: AvatarType.Primary,
     size: AvatarSize.Medium,
     hasTooltip: true,
+    isActive: false,
   },
 };
 

--- a/packages/react-packages/avatar/src/Avatar.styled.ts
+++ b/packages/react-packages/avatar/src/Avatar.styled.ts
@@ -5,10 +5,11 @@ import { AvatarType, AvatarSize } from './constants';
 export interface AvatarStyledProps {
   type: AvatarType;
   size: AvatarSize;
+  isActive?: boolean;
 }
 
 export const AvatarStyled = styled.div<AvatarStyledProps>`
-  ${({ theme, type, size }) => {
+  ${({ theme, type, size, isActive }) => {
     let styles = `
       & > * {
         width: 100%;
@@ -62,7 +63,11 @@ export const AvatarStyled = styled.div<AvatarStyledProps>`
           color: ${theme.palette.content.contrast};
           
           & > * {
-            background-color: ${theme.palette.primary.default};
+            background-color: ${
+              isActive
+                ? theme.palette.primary.dark
+                : theme.palette.primary.default
+            };
 
             &:hover {
               background-color: ${theme.palette.primary.dark};

--- a/packages/react-packages/avatar/src/Avatar.test.tsx
+++ b/packages/react-packages/avatar/src/Avatar.test.tsx
@@ -170,4 +170,31 @@ describe('<Avatar /> component', () => {
     const tooltipContainer = screen.queryByTestId('tooltip-container');
     expect(tooltipContainer).not.toBeInTheDocument();
   });
+
+  it.each`
+    type                  | isActive
+    ${AvatarType.Primary} | ${true}
+    ${AvatarType.Primary} | ${false}
+  `(
+    'should render avatar with type $type when isActive is $isActive',
+    ({ type, isActive }: { type: AvatarType; isActive: boolean }) => {
+      const { getByTestId } = render(
+        <ProvidedAvatar
+          isActive={isActive}
+          size={AvatarSize.Medium}
+          title='User Name'
+          type={type}
+        />
+      );
+
+      const avatar = getByTestId('avatar');
+      const innerElement = avatar.firstChild as HTMLElement;
+
+      const expectedBackgroundColor = isActive ? '#3e3e3e' : '#000000';
+
+      expect(innerElement).toHaveStyle(
+        `background-color: ${expectedBackgroundColor}`
+      );
+    }
+  );
 });

--- a/packages/react-packages/avatar/src/Avatar.tsx
+++ b/packages/react-packages/avatar/src/Avatar.tsx
@@ -13,6 +13,7 @@ export interface AvatarProps extends AvatarStyledProps {
   dataTestId?: string;
   customInitials?: string;
   hasTooltip?: boolean;
+  isActive?: boolean;
 }
 
 const Avatar = ({
@@ -23,6 +24,7 @@ const Avatar = ({
   dataTestId,
   customInitials,
   hasTooltip = true,
+  isActive = false,
 }: AvatarProps) => {
   const [showThumbnail, setShowThumbnail] = useState(false);
 
@@ -43,6 +45,7 @@ const Avatar = ({
         data-testid={dataTestId ?? 'avatar'}
         size={size}
         type={type}
+        isActive={isActive}
       >
         {type === AvatarType.Profile ? (
           renderProfileImage()


### PR DESCRIPTION
## Description

- Add isActive prop to Persist the Avatar active state  

NOTE: this is not a Avatar refactor- is to unblock the task ITCAPI-6061
## Issue

[ITCAPI-6061](https://jir.t3.daimlertruck.com/browse/ITCAPI-6061)

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-72