### PR TITLE
fix: text field helper message element

### DIFF
--- a/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -302,13 +302,13 @@ exports[`<DatePicker /> component onBlur event should render error message when 
     <div
       class="emotion-5"
     >
-      <span
+      <p
         class="emotion-6"
         color="error.default"
         data-testid="typography"
       >
         Please enter a valid date
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -616,13 +616,13 @@ exports[`<DatePicker /> component onBlur event should render error message when 
     <div
       class="emotion-5"
     >
-      <span
+      <p
         class="emotion-6"
         color="error.default"
         data-testid="typography"
       >
         Please enter a valid date
-      </span>
+      </p>
     </div>
   </div>
 </div>

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -246,7 +246,6 @@ export const TextField = ({
         <TextFieldMessageStyled>
           <Typography
             color={showError ? 'error.default' : messageColor}
-            element='span'
             fontStyles='bodySmRegular'
           >
             {message}

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -1788,13 +1788,13 @@ exports[`<TextField /> component should render the TextField with error styles a
     <div
       class="emotion-9 emotion-10"
     >
-      <span
+      <p
         class="emotion-11"
         color="error.default"
         data-testid="typography"
       >
         My Error Message
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -2101,13 +2101,13 @@ exports[`<TextField /> component should render the TextField with info message 1
     <div
       class="emotion-9 emotion-10"
     >
-      <span
+      <p
         class="emotion-11"
         color="content.medium"
         data-testid="typography"
       >
         My Infor Message
-      </span>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION

## Description
The TextFiled message is a standalone piece of text and semanticlly should have a text block.
And considering accessibility examples, helper text is presented as a p element associated with the input.

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots
<img width="481" height="300" alt="Screenshot 2025-11-04 at 11 42 11" src="https://github.com/user-attachments/assets/71cbd4ef-ccfe-4493-8327-80ede82952f1" />

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
