### PR TITLE
fix: text filed extra-suffix visual accessibility

### DIFF
--- a/packages/react-packages/text-field/src/TextField.styled.ts
+++ b/packages/react-packages/text-field/src/TextField.styled.ts
@@ -182,7 +182,7 @@ export const InputExtraSuffixStyled = styled.div<{ isClickable?: boolean }>`
     return `
     display: flex;
     cursor: ${isClickable ? 'pointer' : 'default'};
-    padding-right: ${theme.spacing.spacing_40}};
+    margin-right: ${theme.spacing.spacing_40}};
 
     &:focus-visible {
       outline: 2px solid ${theme.palette.border.dark};

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -579,7 +579,7 @@ exports[`<TextField /> component renders input with extras suffix and prefix ele
   display: -ms-flexbox;
   display: flex;
   cursor: default;
-  padding-right: 12px;
+  margin-right: 12px;
 }
 
 <div>


### PR DESCRIPTION
## Description

when we tab through the  text filed extra-suffix using keyboard the extra-suffix icon has wrong spacing.
This PR should fix the visual accessibility issue by using margin for spacing. 

## Issue

NA

## Screenshots

<img width="385" height="228" alt="Screenshot 2025-11-19 at 16 22 17" src="https://github.com/user-attachments/assets/86231cfb-857d-4c25-8b22-60dc85a42591" />


## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-89