### PR TITLE
fix(release): change automated version commit to comply with commitlint

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -27,7 +27,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
-    if: "!contains(github.event.head_commit.message, 'release:')"
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
 
   delete_previews:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, 'release:')
+    if: github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore(release):')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-fixups:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     needs: lint
     steps:
       - name: Checkout repository
@@ -135,7 +135,7 @@ jobs:
 
   blackduck-scan:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     timeout-minutes: 30
     needs: tests
     env:
@@ -216,7 +216,7 @@ jobs:
 
   sonarqube-scan:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     needs: tests
     steps:
       - name: Checkout repository
@@ -297,7 +297,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'release:') }}
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     needs: [blackduck-scan, sonarqube-scan]
     steps:
       - name: Checkout repository
@@ -314,7 +314,7 @@ jobs:
   generate-version-tag:
     needs: [check-fixups, lint, tests, blackduck-scan, sonarqube-scan, build]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'release:')
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
     steps:
       - name: Generate CI_BOT Token
         id: ci-bot-token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   gather-changed-packages:
-    if: "contains(github.event.head_commit.message, 'release:') || github.event_name == 'workflow_dispatch'"
+    if: ${{ contains(github.event.head_commit.message, 'chore(release):') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.filter-unpublished-packages.outputs.result }}

--- a/packages/changeset-conventional-commits/src/add-tag.ts
+++ b/packages/changeset-conventional-commits/src/add-tag.ts
@@ -39,7 +39,7 @@ export const addTag = () => {
     }
 
     removePrereleaseChangesets();
-    execSync('git add -A && git commit -m "release: version packages"');
+    execSync('git add -A && git commit -m "chore(release): version packages"');
 
     const tagPackages = getPackagesSync(process.cwd()).packages.filter((pkg) =>
       tagPackagesNames.includes(pkg.packageJson.name)


### PR DESCRIPTION
## Description

Fixes a failure in the generate-version-tag step where the automated release commit created by changesets was rejected by commitlint in CI. See https://github.com/daimlertruck/DT-DDS/actions/runs/19508499460/job/55851963010#step:7:37

Currently automated releases and package publishing are blocked.

Commitlint (via @commitlint/config-conventional) does not allow `release` as a valid Conventional Commit type, so Husky's commit-msg hook blocked the commit. As a result, the publish workflow did not run.

- update `add-tag.ts` to use a valid Conventional Commit: chore(release): version packages
- update the changeset utilities to treat `chore(release):` as automation release commits and exclude them from changeset generation.
- update Ci workflow to filter steps with commit message `chore(release):`


## Issue
N/A
<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
