### PR TITLE
fix: guard against SSR access to document.body

### DIFF
--- a/packages/react-packages/core/src/components/Portal.tsx
+++ b/packages/react-packages/core/src/components/Portal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 
 import { createPortal } from 'react-dom';
 
@@ -13,5 +13,15 @@ interface PortalProps {
  * reference -> https://reactjs.org/docs/portals.html
  */
 export const Portal = ({ children, isOpen }: PortalProps) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
   return isOpen ? createPortal(children, document.body) : null;
 };


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->

Previously, accessing `document.body` during server-side rendering caused a "ReferenceError: document is not defined".

This change adds a state guard to ensure the Portal only attempts to mount after the component has hydrated on the client.

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-115