### PR TITLE
fix: inject external css into datepicker bundle

### DIFF
--- a/packages/react-packages/date-picker/tsup.config.ts
+++ b/packages/react-packages/date-picker/tsup.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   entry: ['index.ts'],
   format: ['esm', 'cjs'],
   external: [/@emotion.*/, 'react'],
+  noExternal: [/react-day-picker.*\.css$/],
   dts: true,
+  injectStyle: true,
 });


### PR DESCRIPTION
## Description

The css imported by the dependency `react-day-picker` from node_modules is not allowed in next applications.

Explanation here:
https://nextjs.org/docs/messages/css-npm

To solve that basicaly the external css is injected into the js bundle for the date-picker component.

## Issue

N/A

## Screenshots

<img width="990" height="298" alt="image" src="https://github.com/user-attachments/assets/90293cf4-eeb4-4d84-9b8c-95e4a0b92373" />


## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-118