### PR TITLE
feat: add sidebar compound component

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -90,6 +90,7 @@ const config: StorybookConfig = {
         'spinner',
         'radio',
         'app-header',
+        'sidebar',
       ];
 
       config.resolve.alias = {

--- a/packages/dt-dds-react/index.ts
+++ b/packages/dt-dds-react/index.ts
@@ -50,6 +50,7 @@ export * from '@dt-dds/react-pagination';
 export * from '@dt-dds/react-icon-button';
 export * from '@dt-dds/react-link';
 export * from '@dt-dds/themes';
+export * from '@dt-dds/react-sidebar';
 
 declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/dt-dds-react/package.json
+++ b/packages/dt-dds-react/package.json
@@ -56,6 +56,7 @@
     "@dt-dds/react-toggle": "1.0.0-beta.35",
     "@dt-dds/react-tooltip": "1.0.0-beta.64",
     "@dt-dds/react-typography": "1.0.0-beta.46",
+    "@dt-dds/react-sidebar": "1.0.0-beta.0",
     "@dt-dds/themes": "1.0.0-beta.10",
     "@emotion/server": "^11.4.0",
     "emotion-normalize": "^11.0.1"

--- a/packages/react-packages/sidebar/.eslintrc.js
+++ b/packages/react-packages/sidebar/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['custom'],
+};

--- a/packages/react-packages/sidebar/LICENSE.md
+++ b/packages/react-packages/sidebar/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Daimler Truck AG.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-packages/sidebar/README.md
+++ b/packages/react-packages/sidebar/README.md
@@ -1,0 +1,184 @@
+# Sidebar Package
+
+A compound component for building navigation sidebars with collapsible sections, nested items, and responsive behavior.
+
+## Usage
+
+```jsx
+import { useTheme } from '@emotion/react';
+import { Sidebar, useSidebar } from '@dt-dds/react-sidebar';
+import { Icon } from '@dt-dds/react-icon';
+
+export const App = () => {
+  const theme = useTheme();
+
+  const { isExpanded, toggleSidebar } = useSidebar({ isExpanded: true });
+
+  return (
+    <Sidebar isExpanded={isExpanded} onToggle={toggleSidebar}>
+      <Sidebar.Header show={`(max-width: ${theme.breakpoints.mq3}px)`}>
+        <Sidebar.Item>
+          <Sidebar.Toggle />
+          <span>App Name</span>
+        </Sidebar.Item>
+      </Sidebar.Header>
+
+      <Sidebar.Divider show={`(max-width: ${theme.breakpoints.mq3}px)`} />
+
+      <Sidebar.Content>
+        <Sidebar.Section title='Section One'>
+          <Sidebar.Item href='/'>
+            <Icon code='dashboard' />
+            Menu Item
+          </Sidebar.Item>
+          <Sidebar.Item href='/'>
+            <Icon code='analytics' />
+            Menu Item
+            <Sidebar.SubList>
+              <Sidebar.Item href='/'>Nested Menu Item</Sidebar.Item>
+              <Sidebar.Item href='/'>Nested Menu Item</Sidebar.Item>
+            </Sidebar.SubList>
+          </Sidebar.Item>
+        </Sidebar.Section>
+      </Sidebar.Content>
+
+      <Sidebar.Divider />
+
+      <Sidebar.Footer>
+        <Sidebar.Item href='/settings'>
+          <Icon code='settings' />
+          Settings
+        </Sidebar.Item>
+      </Sidebar.Footer>
+
+      <Sidebar.Divider hide={`(max-width: ${theme.breakpoints.mq3}px)`} />
+
+      <Sidebar.Footer hide={`(max-width: ${theme.breakpoints.mq3}px)`}>
+        <Sidebar.Item>
+          <Sidebar.Toggle />
+          <span>Collapse</span>
+        </Sidebar.Item>
+      </Sidebar.Footer>
+    </Sidebar>
+  );
+};
+```
+
+## API
+
+### Sidebar
+
+| Property     | Type                          | Default  | Description                       |
+| ------------ | ----------------------------- | -------- | --------------------------------- |
+| `isExpanded` | `boolean`                     | required | Controls expanded/collapsed state |
+| `onToggle`   | `(expanded: boolean) => void` | -        | Callback when toggle is triggered |
+| `placement`  | `'left' \| 'right'`           | `'left'` | Desktop sidebar position          |
+| `offsetTop`  | `number`                      | `0`      | Top offset in pixels              |
+| `ariaLabel`  | `string`                      | -        | Accessibility label               |
+
+### Sidebar.Item
+
+| Property          | Type                          | Default | Description                       |
+| ----------------- | ----------------------------- | ------- | --------------------------------- |
+| `href`            | `string`                      | -       | Navigation URL                    |
+| `defaultExpanded` | `boolean`                     | `false` | Initial expanded state (SubList)  |
+| `expanded`        | `boolean`                     | -       | Controlled expanded state         |
+| `onToggle`        | `(expanded: boolean) => void` | -       | Callback when item is toggled     |
+| `children`        | `ReactNode`                   | -       | Item content and optional SubList |
+
+### Sidebar.Section
+
+| Property   | Type        | Default | Description   |
+| ---------- | ----------- | ------- | ------------- |
+| `title`    | `string`    | -       | Section title |
+| `children` | `ReactNode` | -       | Section items |
+
+### Sidebar.SubList
+
+Wrapper for nested `Sidebar.Item` elements. Auto-expands when a child item is active.
+
+### Sidebar.Header / Sidebar.Footer
+
+Fixed position sections at top/bottom of the sidebar.
+
+### Sidebar.Content
+
+Scrollable content area between header and footer.
+
+### Sidebar.Toggle
+
+Button that triggers `onToggle`.
+
+### Sidebar.Divider
+
+Visual separator between sections.
+
+## Hooks
+
+### useSidebar
+
+Standalone state management hook.
+
+```jsx
+const { isExpanded, setIsExpanded, toggleSidebar } = useSidebar({
+  isExpanded: true,
+});
+```
+
+## Custom Link Components
+
+Supports custom link components (React Router, Next.js, etc.):
+
+```jsx
+<Sidebar.Item>
+  <Link to='/dashboard'>
+    <Icon code='dashboard' />
+    Dashboard
+  </Link>
+</Sidebar.Item>
+```
+
+## Stack
+
+- [TypeScript](https://www.typescriptlang.org/) for static type checking
+- [React](https://reactjs.org/) — JavaScript library for user interfaces
+- [Emotion](https://emotion.sh/docs/introduction) — for writing css styles with JavaScript
+- [Storybook](https://storybook.js.org/) — UI component environment powered by Vite
+- [Jest](https://jestjs.io/) - JavaScript Testing Framework
+- [React Testing Library](https://testing-library.com/) - to test UI components in a user-centric way
+- [ESLint](https://eslint.org/) for code linting
+- [Prettier](https://prettier.io) for code formatting
+- [Tsup](https://github.com/egoist/tsup) — TypeScript bundler powered by esbuild
+- [Yarn](https://yarnpkg.com/) from managing packages
+
+## Commands
+
+- `yarn build` - Build the package
+- `yarn dev` - Run the package locally
+- `yarn lint` - Lint all files within this package
+- `yarn test` - Run all unit tests
+- `yarn test:report` - Open the test coverage report
+- `yarn test:update:snapshot` - Run all unit tests and update the snapshot
+
+## Compilation
+
+Running `yarn build` from the root of the package will use [tsup](https://tsup.egoist.dev/) to compile the raw TypeScript and React code to plain JavaScript.
+
+The `/dist` folder contains the compiled output.
+
+```bash
+sidebar
+└── dist
+    ├── index.d.ts  <-- Types
+    ├── index.js    <-- CommonJS version
+    └── index.mjs   <-- ES Modules version
+    ...
+```
+
+## Versioning
+
+Follows [semantic versioning](https://semver.org/)
+
+## &copy; License
+
+Licensed under [MIT License](LICENSE.md)

--- a/packages/react-packages/sidebar/babel.config.js
+++ b/packages/react-packages/sidebar/babel.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  presets: [
+    '@babel/preset-typescript',
+    '@babel/env',
+    [
+      '@babel/react',
+      {
+        runtime: 'automatic',
+      },
+    ],
+  ],
+  plugins: ['@emotion/babel-plugin'],
+};

--- a/packages/react-packages/sidebar/index.ts
+++ b/packages/react-packages/sidebar/index.ts
@@ -1,0 +1,7 @@
+import { Theme as CustomTheme } from '@dt-dds/themes';
+
+export * from './src';
+
+declare module '@emotion/react' {
+  export interface Theme extends CustomTheme {}
+}

--- a/packages/react-packages/sidebar/jest.config.js
+++ b/packages/react-packages/sidebar/jest.config.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const baseConfig = require('jest-config/jest.config.js');
+
+module.exports = {
+  ...baseConfig,
+  moduleNameMapper: {
+    '^@dt-dds/react-(.*)$': ['<rootDir>/../$1/index.ts'],
+    '^@dt-dds/themes$': '<rootDir>/../../themes/src/index.ts',
+  },
+};

--- a/packages/react-packages/sidebar/package.json
+++ b/packages/react-packages/sidebar/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@dt-dds/react-sidebar",
+  "version": "1.0.0-beta.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint --cache .",
+    "test": "jest",
+    "test:report": "open ./jest-coverage/lcov-report/index.html",
+    "test:update:snapshot": "jest -u"
+  },
+  "dependencies": {
+    "@dt-dds/react-core": "1.0.0-beta.55",
+    "@dt-dds/react-icon": "1.0.0-beta.58",
+    "@dt-dds/themes": "1.0.0-beta.10",
+    "@dt-dds/react-tooltip": "1.0.0-beta.64",
+    "@dt-dds/react-typography": "1.0.0-beta.46",
+    "@dt-dds/react-icon-button": "1.0.0-beta.24"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.9",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.22.5",
+    "@babel/preset-typescript": "^7.23.3",
+    "@emotion/babel-plugin": "^11.11.0",
+    "@emotion/css": "^11.7.1",
+    "@emotion/jest": "^11.10.0",
+    "@emotion/react": "^11.8.2",
+    "@emotion/styled": "^11.8.1",
+    "@types/react": "^18.0.9",
+    "@types/react-dom": "^18.0.4",
+    "babel-loader": "^8.3.0",
+    "eslint-config-custom": "*",
+    "eslint-plugin-storybook": "^0.6.12",
+    "jest-config": "*",
+    "react": "^18.1.0",
+    "react-dom": "^18.2.0",
+    "tsconfig": "*",
+    "tsup": "^8.5.0",
+    "typescript": "^4.5.3"
+  },
+  "peerDependencies": {
+    "@emotion/css": "^11.7.1",
+    "@emotion/react": "^11.8.2",
+    "@emotion/styled": "^11.8.1",
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
+  }
+}

--- a/packages/react-packages/sidebar/src/Sidebar.stories.tsx
+++ b/packages/react-packages/sidebar/src/Sidebar.stories.tsx
@@ -1,0 +1,580 @@
+import { useEffect } from 'react';
+
+import { useTheme } from '@emotion/react';
+
+import { AppHeader } from '@dt-dds/react-app-header';
+import { Avatar } from '@dt-dds/react-avatar';
+import { Box } from '@dt-dds/react-box';
+import { useMedia } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
+import { IconButton } from '@dt-dds/react-icon-button';
+import { Typography } from '@dt-dds/react-typography';
+
+import { SIDEBAR_WIDTH, SIDEBAR_WIDTH_MINI } from './constants';
+import { useSidebar } from './hooks';
+import { type SidebarProps, Sidebar } from './Sidebar';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+interface SidebarStory extends Omit<SidebarProps, 'isExpanded'> {
+  isExpanded?: boolean;
+  showMainHeader?: boolean;
+}
+
+const AppHeaderLayout = ({
+  isMobile,
+  toggleSidebar,
+}: {
+  isMobile: boolean;
+  toggleSidebar: () => void;
+}) => {
+  const theme = useTheme();
+  return (
+    <AppHeader
+      style={{
+        borderBottom: `1px solid ${theme.palette.border.default}`,
+      }}
+      type='compact'
+    >
+      <AppHeader.Logo>
+        <Typography
+          color='primary.default'
+          element='p'
+          fontStyles={`${isMobile ? 'h6' : 'h5'}`}
+          id='brandName'
+        >
+          Daimler Truck
+        </Typography>
+      </AppHeader.Logo>
+
+      <AppHeader.AppName name='My App' />
+
+      <AppHeader.Actions position='right'>
+        <IconButton
+          ariaLabel='search'
+          dataTestId='search-btn'
+          onClick={() => null}
+          size='medium'
+          variant='default'
+        >
+          <Icon aria-expanded={false} code='search' />
+        </IconButton>
+        <IconButton
+          ariaLabel='internationalization'
+          dataTestId='language-btn'
+          onClick={() => null}
+          size='medium'
+          variant='default'
+        >
+          <Icon aria-expanded={false} code='language' />
+        </IconButton>
+        <Box
+          style={{
+            flexFlow: 'row nowrap',
+            gap: theme.spacing.spacing_30,
+          }}
+        >
+          {isMobile ? null : (
+            <Typography
+              color='primary.default'
+              element='p'
+              fontStyles='bodySmBold'
+              id='userName'
+            >
+              John Doe
+            </Typography>
+          )}
+          <IconButton
+            aria-controls='userName'
+            aria-expanded='false'
+            aria-haspopup='true'
+            ariaLabel='User Menu'
+          >
+            <Avatar size='medium' title='John Doe' />
+          </IconButton>
+        </Box>
+        {isMobile ? (
+          <IconButton
+            ariaLabel='Toggle sidebar'
+            onClick={toggleSidebar}
+            size='medium'
+            variant='default'
+          >
+            <Icon code='menu_open' />
+          </IconButton>
+        ) : null}
+      </AppHeader.Actions>
+    </AppHeader>
+  );
+};
+
+const StoryLayout = ({
+  children,
+  isExpanded,
+  isMobile,
+  showMainHeader,
+  toggleSidebar,
+}: {
+  children: React.ReactNode;
+  isExpanded: boolean;
+  isMobile: boolean;
+  showMainHeader: boolean;
+  toggleSidebar: () => void;
+}) => {
+  const theme = useTheme();
+  const spacerWidth = isMobile
+    ? 0
+    : isExpanded
+    ? SIDEBAR_WIDTH
+    : SIDEBAR_WIDTH_MINI;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '550px',
+        overflow: 'hidden',
+        backgroundColor: theme.palette.surface.contrast,
+        display: 'flex',
+        flexFlow: 'row nowrap',
+      }}
+    >
+      <div
+        style={{
+          width: spacerWidth,
+          flexShrink: 0,
+          transition: 'width 0.2s ease-in-out',
+        }}
+      />
+      {showMainHeader ? (
+        <AppHeaderLayout isMobile={isMobile} toggleSidebar={toggleSidebar} />
+      ) : null}
+      {children}
+      <main
+        style={{
+          display: 'flex',
+          flex: '1 1 0%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: theme.palette.surface.light,
+          padding: theme.spacing.spacing_60,
+        }}
+      >
+        <Typography color='content.default' fontStyles='bodyLgRegular'>
+          Main content area
+        </Typography>
+      </main>
+    </div>
+  );
+};
+
+const SidebarDemo = (props: SidebarStory) => {
+  const theme = useTheme();
+  const isMobile = useMedia(`(max-width: ${theme.breakpoints.mq3}px)`);
+
+  // Use useSidebar hook to manage state externally
+  const { isExpanded, setIsExpanded, toggleSidebar } = useSidebar({
+    isExpanded: props.isExpanded ?? !isMobile,
+  });
+
+  const showMainHeader = props.showMainHeader ?? false;
+
+  const mainHeaderheight = isMobile ? 72 : 64;
+
+  const offsetTop = showMainHeader ? mainHeaderheight : 0;
+
+  const mockHref =
+    typeof window !== 'undefined' ? window.location.pathname : '/';
+
+  // Sync Storybook control with hook state
+  useEffect(() => {
+    if (props.isExpanded !== undefined) {
+      setIsExpanded(props.isExpanded);
+    }
+  }, [props.isExpanded, setIsExpanded]);
+
+  return (
+    <StoryLayout
+      isExpanded={isExpanded}
+      isMobile={isMobile}
+      showMainHeader={showMainHeader}
+      toggleSidebar={toggleSidebar}
+    >
+      <Sidebar
+        ariaLabel='Sidebar navigation'
+        isExpanded={isExpanded}
+        offsetTop={props.offsetTop || offsetTop}
+        onToggle={toggleSidebar}
+        placement={props.placement}
+      >
+        <Sidebar.Header show={`(max-width: ${theme.breakpoints.mq3}px)`}>
+          <Sidebar.Item>
+            <Sidebar.Toggle />
+            <Typography color='primary.default' element='h2' fontStyles='h5'>
+              Daimler Truck
+            </Typography>
+          </Sidebar.Item>
+        </Sidebar.Header>
+
+        <Sidebar.Divider show={`(max-width: ${theme.breakpoints.mq3}px)`} />
+
+        <Sidebar.Content>
+          <Sidebar.Section>
+            <Sidebar.Item href='/'>
+              <Icon code='dashboard' />
+              Dashboard
+            </Sidebar.Item>
+          </Sidebar.Section>
+          <Sidebar.Divider />
+          <Sidebar.Section title='Sales Management'>
+            <Sidebar.Item href={mockHref}>
+              <Icon code='finance' />
+              Sales & Quotes
+              <Sidebar.SubList>
+                <Sidebar.Item href={mockHref}>All Quotes</Sidebar.Item>
+                <Sidebar.Item href='/sales-and-quotes/pending'>
+                  Pending Quotes
+                </Sidebar.Item>
+                <Sidebar.Item href='/sales-and-quotes/new'>
+                  New Quote
+                </Sidebar.Item>
+              </Sidebar.SubList>
+            </Sidebar.Item>
+          </Sidebar.Section>
+
+          <Sidebar.Divider />
+
+          <Sidebar.Section title='Customer Management'>
+            <Sidebar.Item href='/credit-applications'>
+              <Icon code='credit_score' />
+              Credit Applications
+            </Sidebar.Item>
+            <Sidebar.Item href='/contracts'>
+              <Icon code='contract_edit' />
+              Contracts
+            </Sidebar.Item>
+            <Sidebar.Item href='/customers'>
+              <Icon code='person_pin' />
+              Customers
+            </Sidebar.Item>
+          </Sidebar.Section>
+        </Sidebar.Content>
+
+        <Sidebar.Footer>
+          <Sidebar.Item href='/dashboard'>
+            <Icon code='book' />
+            <Typography color='inherit' element='span' fontStyles='bodyMdBold'>
+              Terms of Use
+            </Typography>
+          </Sidebar.Item>
+          <Sidebar.Item>
+            <IconButton ariaLabel='User profile' onClick={() => null}>
+              <Avatar size='medium' title='Account' type='thumbnail' />
+            </IconButton>
+            <Typography
+              color='inherit'
+              element='span'
+              fontStyles='bodyMdBold'
+              onClick={() => null}
+              onKeyDown={() => null}
+              role='button'
+              tabIndex={0}
+            >
+              Account
+            </Typography>
+          </Sidebar.Item>
+        </Sidebar.Footer>
+
+        <Sidebar.Divider hide={`(max-width: ${theme.breakpoints.mq3}px)`} />
+
+        <Sidebar.Footer hide={`(max-width: ${theme.breakpoints.mq3}px)`}>
+          <Sidebar.Item>
+            <Sidebar.Toggle />
+            <Typography
+              color='inherit'
+              element='span'
+              fontStyles='bodyMdBold'
+              onClick={toggleSidebar}
+              onKeyDown={toggleSidebar}
+              role='button'
+              tabIndex={0}
+            >
+              Collapse
+            </Typography>
+          </Sidebar.Item>
+        </Sidebar.Footer>
+      </Sidebar>
+    </StoryLayout>
+  );
+};
+
+const meta: Meta<SidebarStory> = {
+  title: 'Compound Components/Sidebar',
+  component: Sidebar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A compound component for building navigation sidebars. State is managed externally via `useSidebar` hook.',
+      },
+    },
+  },
+  args: {
+    isExpanded: true,
+    placement: 'left',
+    offsetTop: 0,
+  },
+  argTypes: {
+    isExpanded: {
+      control: 'boolean',
+      description: 'Controls sidebar expanded/collapsed state',
+      defaultValue: {
+        summary: true,
+      },
+    },
+    placement: {
+      control: {
+        type: 'inline-radio',
+      },
+      options: ['left', 'right'],
+      description: 'Sidebar position on desktop',
+      defaultValue: {
+        summary: 'left',
+      },
+    },
+    offsetTop: {
+      control: 'number',
+      description: 'Sidebar top offset in pixels',
+      defaultValue: {
+        summary: 0,
+      },
+    },
+  },
+  render: (args: SidebarStory) => <SidebarDemo {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<SidebarStory>;
+
+const defaultUsageCode = `
+import { useTheme } from '@emotion/react';
+import { useMedia } from '@dt-dds/react-core';
+
+import { Icon } from '@dt-dds/react-icon';
+import { Typography } from '@dt-dds/react-typography';
+import { Sidebar, useSidebar } from '@dt-dds/react-sidebar';
+
+const App = () => {
+  const theme = useTheme();
+  const isMobile = useMedia(\`(max-width: \${theme.breakpoints.mq3}px)\`);
+
+  const { isExpanded, toggleSidebar } = useSidebar({
+    isExpanded: !isMobile,
+  });
+
+  return (
+    <Sidebar isExpanded={isExpanded} onToggle={toggleSidebar}>
+      <Sidebar.Header show={\`(max-width: \${theme.breakpoints.mq3}px)\`}>
+        <Sidebar.Item>
+          <Sidebar.Toggle />
+          <Typography color='primary.default' element='h2' fontStyles='h5'>
+            Daimler Truck
+          </Typography>
+        </Sidebar.Item>
+      </Sidebar.Header>
+      
+      <Sidebar.Divider show={\`(max-width: \${theme.breakpoints.mq3}px)\`} />
+      
+      <Sidebar.Content>
+        <Sidebar.Section>
+          <Sidebar.Item href='/'>
+            <Icon code='dashboard' />
+            Dashboard
+          </Sidebar.Item>
+        </Sidebar.Section>
+
+        <Sidebar.Divider />
+
+        <Sidebar.Section title="Section Two">
+          <Sidebar.Item href="/sales-and-quotes/all">
+            <Icon code="finance" />
+            Sales & Quotes
+            <Sidebar.SubList>
+              <Sidebar.Item href='/sales-and-quotes/all'>
+                All Quotes
+              </Sidebar.Item>
+              <Sidebar.Item href='/sales-and-quotes/pending'>
+                Pending Quotes
+              </Sidebar.Item>
+              <Sidebar.Item href='/sales-and-quotes/new'>
+                New Quote
+              </Sidebar.Item>
+            </Sidebar.SubList>
+          </Sidebar.Item>
+        </Sidebar.Section>
+
+        <Sidebar.Divider />
+
+        <Sidebar.Section title="Section Three">
+          <Sidebar.Item href="/credit-applications">
+            <Icon code="credit_score" />
+            Credit Applications
+          </Sidebar.Item>
+          <Sidebar.Item href="/contracts">
+            <Icon code="contract_edit" />
+            Contracts
+          </Sidebar.Item>
+          <Sidebar.Item href="/customers">
+            <Icon code="person_pin" />
+            Customers
+          </Sidebar.Item>
+        </Sidebar.Section>
+      </Sidebar.Content>
+      
+      <Sidebar.Footer>
+        <Sidebar.Item href='/terms-of-use'>
+          <Icon code='book' />
+          <Typography color='inherit' element='span' fontStyles='bodyMdBold'>
+            Terms of Use
+          </Typography>
+        </Sidebar.Item>
+        <Sidebar.Item>
+          <IconButton ariaLabel='User profile' onClick={() => null}>
+            <Avatar size='medium' title='Account' type='thumbnail' />
+          </IconButton>
+          <Typography
+            color='inherit'
+            element='span'
+            fontStyles='bodyMdBold'
+            onClick={() => null}
+            onKeyDown={() => null}
+            role='button'
+            tabIndex={0}
+          >
+            Account
+          </Typography>
+        </Sidebar.Item>
+      </Sidebar.Footer>
+
+      <Sidebar.Divider hide={\`(max-width: \${theme.breakpoints.mq3}px)\`} />
+      
+      <Sidebar.Footer hide={\`(max-width: \${theme.breakpoints.mq3}px)\`}>
+        <Sidebar.Item>
+          <Sidebar.Toggle />
+          <Typography color='inherit' element='span' fontStyles='bodyMdBold'>
+            Collapse
+          </Typography>
+        </Sidebar.Item>
+      </Sidebar.Footer>
+    </Sidebar>
+  );
+};
+`;
+
+export const Default: Story = {
+  name: 'Default',
+  parameters: {
+    docs: {
+      source: {
+        code: defaultUsageCode,
+        language: 'tsx',
+      },
+    },
+  },
+};
+
+const customLinkCode = `
+import Link from 'next/link'; // or react-router-dom, etc.
+
+<Sidebar.Item>
+  <Link href="/dashboard">
+    <Icon code="dashboard" />
+    Dashboard
+  </Link>
+</Sidebar.Item>
+`;
+
+export const WithCustomLink: Story = {
+  name: 'With custom link element',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Use your own link component (Next.js, React Router, etc.) by wrapping it inside `Sidebar.Item`.',
+      },
+      source: {
+        code: customLinkCode,
+        language: 'tsx',
+      },
+    },
+  },
+  args: {},
+};
+
+const withMainHeaderCode = `
+import { useTheme } from '@emotion/react';
+import { useMedia } from '@dt-dds/react-core';
+
+import { Typography } from '@dt-dds/react-typography';
+import { IconButton } from '@dt-dds/react-icon-button';
+
+import { AppHeader } from '@dt-dds/react-app-header';
+import { Sidebar, useSidebar } from '@dt-dds/react-sidebar';
+
+const App = () => {
+  const theme = useTheme();
+  const isMobile = useMedia(\`(max-width: \${theme.breakpoints.mq3}px)\`);
+
+  const { isExpanded, toggleSidebar } = useSidebar({
+    isExpanded: !isMobile,
+  });
+
+  // AppHeader height
+  const offsetTop = isMobile ? 72 : 64;
+
+  return (
+    <AppHeader type='compact'>
+      <AppHeader.Logo>
+        <Typography color='primary.default' element='p' fontStyles='h5'>
+          Daimler Truck
+        </Typography>
+      </AppHeader.Logo>
+      
+      <AppHeader.AppName name='My App' />
+      
+      <AppHeader.Actions position='right' show={\`(max-width: \${theme.breakpoints.mq3}px)\`}>
+        <IconButton ariaLabel='Toggle sidebar' onClick={toggleSidebar} size='medium' variant='default'>
+          <Icon code='menu_open' />
+        </IconButton>
+      </AppHeader.Actions>
+    </AppHeader>
+
+    <Sidebar isExpanded={isExpanded} offsetTop={offsetTop} onToggle={toggleSidebar}>
+      // Sidebar content
+    </Sidebar>
+  );
+};
+`;
+
+export const withMainHeader: Story = {
+  name: 'With AppHeader',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Use with `AppHeader` compound component to create a complete web application shell.',
+      },
+      source: {
+        code: withMainHeaderCode,
+        language: 'tsx',
+      },
+    },
+  },
+  args: {
+    showMainHeader: true,
+  },
+};

--- a/packages/react-packages/sidebar/src/Sidebar.styled.ts
+++ b/packages/react-packages/sidebar/src/Sidebar.styled.ts
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+
+import {
+  SIDEBAR_DEFAULT_OFFSET_TOP,
+  SIDEBAR_DEFAULT_TRANSITION,
+} from './constants';
+import { calculateSidebarPosition, calculateSidebarWidth } from './utils';
+
+import type { SidebarPlacement } from './types';
+
+export interface SidebarStyledProps {
+  isMobile: boolean;
+  isExpanded: boolean;
+  offsetTop: number;
+  placement: SidebarPlacement;
+}
+
+export const SidebarStyled = styled.aside<SidebarStyledProps>`
+  ${({ theme, isExpanded, isMobile, offsetTop, placement }) => {
+    const height = isMobile ? SIDEBAR_DEFAULT_OFFSET_TOP : offsetTop;
+
+    const width = calculateSidebarWidth(isMobile, isExpanded);
+
+    const sidebarPositionValue = calculateSidebarPosition(isMobile, isExpanded);
+
+    const transitionAnimation = SIDEBAR_DEFAULT_TRANSITION;
+
+    return `
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      height: calc(100% - ${height}px);
+      width: ${width}px;
+      background-color: ${theme.palette.surface.contrast};
+      overflow: hidden;
+      top: ${offsetTop}px;
+      transition: ${transitionAnimation};
+      ${placement}: ${sidebarPositionValue}px;
+
+      ${
+        placement === 'right'
+          ? `border-left: 1px solid ${theme.palette.border.default};`
+          : `border-right: 1px solid ${theme.palette.border.default};`
+      }
+    `;
+  }}
+`;

--- a/packages/react-packages/sidebar/src/Sidebar.test.tsx
+++ b/packages/react-packages/sidebar/src/Sidebar.test.tsx
@@ -1,0 +1,197 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { useMedia, withProviders } from '@dt-dds/react-core';
+
+import {
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_MINI,
+  SIDEBAR_DEFAULT_OFFSET_TOP,
+  SIDEBAR_DEFAULT_OFFSET_POSITION,
+  SIDEBAR_DEFAULT_TRANSITION,
+} from './constants';
+import { Sidebar } from './Sidebar';
+
+jest.mock('@dt-dds/react-core', () => ({
+  ...jest.requireActual('@dt-dds/react-core'),
+  useMedia: jest.fn(() => false),
+}));
+
+const mockedUseMedia = useMedia as jest.Mock;
+
+const transitionAnimation = SIDEBAR_DEFAULT_TRANSITION;
+
+describe('<Sidebar />', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedUseMedia.mockReturnValue(false); // desktop
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('renders with correct structure', () => {
+    const { container } = render(
+      <ProvidedSidebar ariaLabel='Navigation' dataTestId='sidebar' isExpanded>
+        <div>Content</div>
+      </ProvidedSidebar>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('desktop mode', () => {
+    it('renders expanded with correct styles', () => {
+      const { container } = render(
+        <ProvidedSidebar dataTestId='sidebar' isExpanded offsetTop={60} />
+      );
+      const sidebar = container.querySelector('[data-testid="sidebar"]');
+
+      expect(sidebar).toHaveStyle({
+        width: `${SIDEBAR_WIDTH}px`,
+        left: '0px',
+        top: '60px',
+        transition: transitionAnimation,
+      });
+      expect(screen.queryByTestId('mobile-backdrop')).toBeNull();
+    });
+
+    it('renders collapsed with mini width', () => {
+      const { container } = render(
+        <ProvidedSidebar dataTestId='sidebar' isExpanded={false} />
+      );
+      const sidebar = container.querySelector('[data-testid="sidebar"]');
+      expect(sidebar).toHaveStyle({ width: `${SIDEBAR_WIDTH_MINI}px` });
+    });
+  });
+
+  describe('mobile mode', () => {
+    beforeEach(() => {
+      mockedUseMedia.mockReturnValue(true);
+    });
+
+    it('renders collapsed without backdrop', () => {
+      render(<ProvidedSidebar dataTestId='sidebar' isExpanded={false} />);
+      expect(screen.queryByTestId('mobile-backdrop')).toBeNull();
+    });
+
+    it('expands with backdrop and correct styles', () => {
+      const { container } = render(
+        <ProvidedSidebar dataTestId='sidebar' isExpanded offsetTop={60} />
+      );
+
+      expect(screen.getByTestId('mobile-backdrop')).toBeInTheDocument();
+
+      act(() => jest.advanceTimersByTime(50));
+
+      const sidebar = container.querySelector('[data-testid="sidebar"]');
+      expect(sidebar).toHaveStyle({
+        width: `${SIDEBAR_WIDTH}px`,
+        right: `${SIDEBAR_DEFAULT_OFFSET_POSITION}px`,
+        top: `${SIDEBAR_DEFAULT_OFFSET_TOP}px`, // offsetTop ignored on mobile
+        transition: transitionAnimation,
+      });
+    });
+
+    it('collapses with animation sequence', () => {
+      const { container, rerender } = render(
+        <ProvidedSidebar dataTestId='sidebar' isExpanded />
+      );
+
+      act(() => jest.advanceTimersByTime(50));
+      expect(screen.getByTestId('mobile-backdrop')).toBeInTheDocument();
+
+      rerender(<ProvidedSidebar dataTestId='sidebar' isExpanded={false} />);
+
+      const sidebar = container.querySelector('[data-testid="sidebar"]');
+      expect(sidebar).toHaveStyle({ right: `-${SIDEBAR_WIDTH}px` });
+
+      act(() => jest.advanceTimersByTime(200));
+      expect(screen.queryByTestId('mobile-backdrop')).toBeNull();
+    });
+  });
+
+  describe('onToggle callback', () => {
+    it('calls onToggle on backdrop click', () => {
+      mockedUseMedia.mockReturnValue(true);
+      const handleToggle = jest.fn();
+
+      render(<ProvidedSidebar isExpanded onToggle={handleToggle} />);
+
+      act(() => jest.advanceTimersByTime(50));
+      fireEvent.click(screen.getByTestId('mobile-backdrop'));
+
+      expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    it('calls onToggle with false when expanded and toggled', () => {
+      mockedUseMedia.mockReturnValue(true);
+      const handleToggle = jest.fn();
+
+      render(<ProvidedSidebar isExpanded onToggle={handleToggle} />);
+
+      act(() => jest.advanceTimersByTime(50));
+      fireEvent.click(screen.getByTestId('mobile-backdrop'));
+
+      expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    it('calls onToggle with false when pressing Escape key on mobile', () => {
+      mockedUseMedia.mockReturnValue(true);
+      const handleToggle = jest.fn();
+
+      render(<ProvidedSidebar isExpanded onToggle={handleToggle} />);
+
+      act(() => jest.advanceTimersByTime(50));
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    it('does not call onToggle on Escape when sidebar is collapsed', () => {
+      mockedUseMedia.mockReturnValue(true);
+      const handleToggle = jest.fn();
+
+      render(<ProvidedSidebar isExpanded={false} onToggle={handleToggle} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(handleToggle).not.toHaveBeenCalled();
+    });
+
+    it('does not call onToggle on Escape in desktop mode', () => {
+      mockedUseMedia.mockReturnValue(false);
+      const handleToggle = jest.fn();
+
+      render(<ProvidedSidebar isExpanded onToggle={handleToggle} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(handleToggle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears timeout on unmount and state changes', () => {
+      mockedUseMedia.mockReturnValue(true);
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      const { rerender, unmount } = render(
+        <ProvidedSidebar dataTestId='sidebar' isExpanded />
+      );
+
+      rerender(<ProvidedSidebar dataTestId='sidebar' isExpanded={false} />);
+      const callsAfterRerender = clearTimeoutSpy.mock.calls.length;
+      expect(callsAfterRerender).toBeGreaterThan(0);
+
+      unmount();
+      expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(
+        callsAfterRerender
+      );
+
+      clearTimeoutSpy.mockRestore();
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/Sidebar.tsx
+++ b/packages/react-packages/sidebar/src/Sidebar.tsx
@@ -1,0 +1,171 @@
+import {
+  useMemo,
+  useCallback,
+  HTMLAttributes,
+  useState,
+  useEffect,
+  useRef,
+} from 'react';
+
+import { useTheme } from '@emotion/react';
+
+import { useMedia } from '@dt-dds/react-core';
+
+import {
+  SidebarBackdrop,
+  SidebarDivider,
+  SidebarSection,
+  SidebarItem,
+  SidebarSubList,
+  SidebarContent,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarToggle,
+} from './components';
+import {
+  SIDEBAR_DEFAULT_PLACEMENT,
+  SIDEBAR_MOBILE_PLACEMENT,
+  SIDEBAR_DEFAULT_OFFSET_TOP,
+  SIDEBAR_BACKDROP_SHOW_DELAY,
+  SIDEBAR_BACKDROP_HIDE_DELAY,
+} from './constants';
+import { SidebarContextValue, SidebarContextProvider } from './context';
+import { SidebarStyled } from './Sidebar.styled';
+
+import type { SidebarPlacement } from './types';
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarProps extends BaseProps, HTMLAttributes<HTMLElement> {
+  ariaLabel?: string;
+  isExpanded: boolean;
+  offsetTop?: number;
+  placement?: SidebarPlacement;
+  onToggle?: (expanded: boolean) => void;
+}
+
+export const Sidebar = ({
+  dataTestId,
+  offsetTop = 0,
+  children,
+  ariaLabel,
+  style,
+  isExpanded,
+  placement = SIDEBAR_DEFAULT_PLACEMENT,
+  onToggle,
+  ...rest
+}: SidebarProps) => {
+  const theme = useTheme();
+  const isMobile = useMedia(`(max-width: ${theme.breakpoints.mq3}px)`);
+
+  // Backdrop visibility and sidebar expansion state for animation
+  const [isBackdropVisible, setIsBackdropVisible] = useState(false);
+  const [shouldShowSidebar, setShouldShowSidebar] = useState(
+    !isMobile && isExpanded
+  );
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    if (!isMobile) {
+      setIsBackdropVisible(false);
+      setShouldShowSidebar(isExpanded);
+      return;
+    }
+
+    if (isExpanded) {
+      setIsBackdropVisible(true);
+      timeoutRef.current = window.setTimeout(() => {
+        setShouldShowSidebar(true);
+      }, SIDEBAR_BACKDROP_SHOW_DELAY);
+    } else {
+      setShouldShowSidebar(false);
+      timeoutRef.current = window.setTimeout(() => {
+        setIsBackdropVisible(false);
+      }, SIDEBAR_BACKDROP_HIDE_DELAY);
+    }
+
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [isExpanded, isMobile]);
+
+  // Handle Escape key to close sidebar
+  useEffect(() => {
+    if (!isMobile || !isExpanded) return;
+
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onToggle?.(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscapeKey);
+    return () => document.removeEventListener('keydown', handleEscapeKey);
+  }, [isMobile, isExpanded, onToggle]);
+
+  const handleToggle = useCallback(() => {
+    onToggle?.(!isExpanded);
+  }, [onToggle, isExpanded]);
+
+  const contextValue: SidebarContextValue = useMemo(
+    () => ({
+      isExpanded,
+      isMobile,
+      onToggle: handleToggle,
+    }),
+    [isExpanded, isMobile, handleToggle]
+  );
+
+  return (
+    <SidebarContextProvider value={contextValue}>
+      {isMobile ? (
+        <SidebarBackdrop
+          dataTestId='mobile-backdrop'
+          isOpen={isBackdropVisible}
+          onBackdropClick={handleToggle}
+        >
+          <SidebarStyled
+            aria-label={ariaLabel}
+            data-testid={dataTestId}
+            isExpanded={shouldShowSidebar}
+            isMobile={isMobile}
+            offsetTop={SIDEBAR_DEFAULT_OFFSET_TOP}
+            placement={SIDEBAR_MOBILE_PLACEMENT}
+            style={style}
+            {...rest}
+          >
+            {children}
+          </SidebarStyled>
+        </SidebarBackdrop>
+      ) : (
+        <SidebarStyled
+          aria-label={ariaLabel}
+          data-testid={dataTestId}
+          isExpanded={isExpanded}
+          isMobile={isMobile}
+          offsetTop={offsetTop}
+          placement={placement}
+          style={style}
+          {...rest}
+        >
+          {children}
+        </SidebarStyled>
+      )}
+    </SidebarContextProvider>
+  );
+};
+
+Sidebar.Content = SidebarContent;
+Sidebar.Divider = SidebarDivider;
+Sidebar.Section = SidebarSection;
+Sidebar.Item = SidebarItem;
+Sidebar.SubList = SidebarSubList;
+Sidebar.Header = SidebarHeader;
+Sidebar.Footer = SidebarFooter;
+Sidebar.Toggle = SidebarToggle;

--- a/packages/react-packages/sidebar/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/react-packages/sidebar/src/__snapshots__/Sidebar.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Sidebar /> renders with correct structure 1`] = `
+.emotion-0 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: calc(100% - 0px);
+  width: 250px;
+  background-color: #ffffff;
+  overflow: hidden;
+  top: 0px;
+  -webkit-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  left: 0px;
+  border-right: 1px solid #e6e6e6;
+}
+
+<aside
+  aria-label="Navigation"
+  class="emotion-0 emotion-1"
+  data-testid="sidebar"
+>
+  <div>
+    Content
+  </div>
+</aside>
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.styled.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import { BACKDROP_Z_INDEX } from '@dt-dds/react-core';
+import { hexToRgba } from '@dt-dds/themes';
+
+export interface SidebarBackdropStyledProps {
+  isOpen: boolean;
+}
+
+export const SidebarBackdropStyled = styled.div<SidebarBackdropStyledProps>`
+  ${({ theme, isOpen }) => {
+    if (!isOpen) {
+      return 'display: none;';
+    }
+
+    return `
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background: ${hexToRgba(theme.palette.surface.dark, 0.2)};
+      z-index: ${BACKDROP_Z_INDEX};
+      overflow: hidden;
+    `;
+  }}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+
+import { SidebarBackdrop } from './SidebarBackdrop';
+import { SidebarBackdropStyled } from './SidebarBackdrop.styled';
+
+describe('<SidebarBackdrop /> component', () => {
+  const ProvidedSidebarBackdrop = withProviders(SidebarBackdrop);
+
+  it('renders when isOpen is true', () => {
+    render(
+      <ProvidedSidebarBackdrop isOpen>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    expect(backdrop).toBeInTheDocument();
+    expect(backdrop).toHaveTextContent('Test content');
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <ProvidedSidebarBackdrop isOpen={false}>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    expect(screen.queryByTestId('sidebar-backdrop')).toBeNull();
+  });
+
+  it('applies display none style when isOpen is false', () => {
+    const TestComponent = withProviders(SidebarBackdropStyled);
+
+    const { container } = render(
+      <TestComponent data-testid='test-backdrop' isOpen={false} />
+    );
+    const element = container.querySelector(
+      '[data-testid="test-backdrop"]'
+    ) as HTMLElement;
+
+    expect(element).toHaveStyle({ display: 'none' });
+  });
+
+  it('calls onBackdropClick when clicking directly on backdrop', () => {
+    const handleBackdropClick = jest.fn();
+
+    render(
+      <ProvidedSidebarBackdrop isOpen onBackdropClick={handleBackdropClick}>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    fireEvent.click(backdrop);
+
+    expect(handleBackdropClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onBackdropClick when clicking on children', () => {
+    const handleBackdropClick = jest.fn();
+
+    render(
+      <ProvidedSidebarBackdrop isOpen onBackdropClick={handleBackdropClick}>
+        <div data-testid='child-content'>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    const child = screen.getByTestId('child-content');
+    fireEvent.click(child);
+
+    expect(handleBackdropClick).not.toHaveBeenCalled();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <ProvidedSidebarBackdrop isOpen>
+        <div data-testid='child-1'>Child 1</div>
+        <div data-testid='child-2'>Child 2</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    expect(screen.getByTestId('child-1')).toBeInTheDocument();
+    expect(screen.getByTestId('child-2')).toBeInTheDocument();
+  });
+
+  it('uses custom dataTestId when provided', () => {
+    render(
+      <ProvidedSidebarBackdrop dataTestId='custom-backdrop' isOpen>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    expect(screen.getByTestId('custom-backdrop')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-backdrop')).toBeNull();
+  });
+
+  it('uses default dataTestId when not provided', () => {
+    render(
+      <ProvidedSidebarBackdrop isOpen>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    expect(screen.getByTestId('sidebar-backdrop')).toBeInTheDocument();
+  });
+
+  it('does not call onBackdropClick when handler is not provided', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <ProvidedSidebarBackdrop isOpen>
+        <div>Test content</div>
+      </ProvidedSidebarBackdrop>
+    );
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    fireEvent.click(backdrop);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarBackdrop/SidebarBackdrop.tsx
@@ -1,0 +1,43 @@
+import { MouseEvent, useCallback } from 'react';
+
+import { SidebarBackdropStyled } from './SidebarBackdrop.styled';
+
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarBackdropProps extends BaseProps {
+  isOpen: boolean;
+  onBackdropClick?: () => void;
+  children: React.ReactNode;
+}
+
+export const SidebarBackdrop = ({
+  isOpen,
+  onBackdropClick,
+  children,
+  dataTestId,
+}: SidebarBackdropProps) => {
+  const handleBackdropClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget && onBackdropClick) {
+        onBackdropClick();
+      }
+    },
+    [onBackdropClick]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <SidebarBackdropStyled
+      data-testid={dataTestId ?? 'sidebar-backdrop'}
+      isOpen={isOpen}
+      onClick={handleBackdropClick}
+    >
+      {children}
+    </SidebarBackdropStyled>
+  );
+};
+
+SidebarBackdrop.displayName = 'Sidebar.Backdrop';

--- a/packages/react-packages/sidebar/src/components/SidebarBackdrop/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarBackdrop/index.ts
@@ -1,0 +1,2 @@
+export { SidebarBackdrop } from './SidebarBackdrop';
+export type { SidebarBackdropProps } from './SidebarBackdrop';

--- a/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.styled.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const SidebarContentStyled = styled.div<{ isSidebarCollapsed: boolean }>`
+  ${({ theme, isSidebarCollapsed }) => {
+    return `
+      position: relative;
+      display: block;
+      flex: 1 1 auto;
+      overflow-x: hidden;
+      overflow-y: overlay;
+      scrollbar-width: ${isSidebarCollapsed ? 'none' : 'thin'};
+      scrollbar-color: ${theme.palette.border.default} transparent;
+    `;
+  }}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+
+import { SidebarContextProvider } from '../../context';
+import { SidebarSection } from '../SidebarSection';
+import { SidebarContent } from './SidebarContent';
+
+describe('<SidebarContent /> component', () => {
+  const ProvidedContent = withProviders(SidebarContent);
+  const ProvidedSection = withProviders(SidebarSection);
+  const mockContextValue = {
+    isExpanded: true,
+    isMobile: false,
+  };
+
+  const renderContent = (children: React.ReactNode, props = {}) => {
+    return render(
+      <SidebarContextProvider value={mockContextValue}>
+        <ProvidedContent {...props}>{children}</ProvidedContent>
+      </SidebarContextProvider>
+    );
+  };
+
+  it('wraps SidebarSection components', () => {
+    renderContent(
+      <ProvidedSection title='Test Section'>
+        <div>Section Content</div>
+      </ProvidedSection>
+    );
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.getByText('Section Content')).toBeInTheDocument();
+  });
+
+  it('has overflow styles for scrolling when content overflows', () => {
+    const { container } = renderContent(<div>Content</div>);
+    const content = container.querySelector('[data-testid="sidebar-content"]');
+    expect(content).toHaveStyle({ 'overflow-y': 'overlay' });
+  });
+
+  it('uses default data-testid when not provided', () => {
+    renderContent(<div>Content</div>);
+    expect(screen.getByTestId('sidebar-content')).toBeInTheDocument();
+  });
+
+  it('uses custom dataTestId when provided', () => {
+    renderContent(<div>Content</div>, { dataTestId: 'custom-content' });
+    expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-content')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarContent/SidebarContent.tsx
@@ -1,0 +1,35 @@
+import { HTMLAttributes, ReactNode } from 'react';
+
+import { SidebarContentStyled } from './SidebarContent.styled';
+import { useSidebarContext } from '../../context';
+
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarContentProps
+  extends BaseProps,
+    HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+}
+
+export const SidebarContent = ({
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: SidebarContentProps) => {
+  const { isExpanded, isMobile } = useSidebarContext();
+  const isSidebarCollapsed = !isMobile && !isExpanded;
+
+  return (
+    <SidebarContentStyled
+      data-testid={dataTestId ?? 'sidebar-content'}
+      isSidebarCollapsed={isSidebarCollapsed}
+      style={style}
+      {...rest}
+    >
+      {children}
+    </SidebarContentStyled>
+  );
+};
+
+SidebarContent.displayName = 'Sidebar.Content';

--- a/packages/react-packages/sidebar/src/components/SidebarContent/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarContent/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarContent';

--- a/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.styled.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const SidebarDividerStyled = styled.hr`
+  ${({ theme }) => `
+    height: 1px;
+    margin: ${theme.spacing.spacing_0};
+    border: none;
+    background-color: ${theme.palette.border.default};
+  `}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+
+import { SidebarDivider } from './SidebarDivider';
+
+describe('<SidebarDivider /> component', () => {
+  const ProvidedDivider = withProviders(SidebarDivider);
+
+  it('renders with default data-testid', () => {
+    render(<ProvidedDivider />);
+
+    const divider = screen.getByTestId('sidebar-divider');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('uses custom dataTestId when provided', () => {
+    render(<ProvidedDivider dataTestId='custom-divider' />);
+
+    expect(screen.getByTestId('custom-divider')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-divider')).not.toBeInTheDocument();
+  });
+
+  it('renders as an hr separator element', () => {
+    render(<ProvidedDivider />);
+
+    const divider = screen.getByRole('separator');
+    expect(divider.tagName.toLowerCase()).toBe('hr');
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarDivider/SidebarDivider.tsx
@@ -1,0 +1,32 @@
+import { HTMLAttributes } from 'react';
+
+import {
+  type ResponsiveProps,
+  type BaseProps,
+  withResponsive,
+} from '@dt-dds/react-core';
+
+import { SidebarDividerStyled } from './SidebarDivider.styled';
+
+export interface SidebarDividerProps
+  extends ResponsiveProps,
+    BaseProps,
+    HTMLAttributes<HTMLHRElement> {}
+
+const SidebarDividerBase = ({
+  dataTestId,
+  style,
+  ...rest
+}: Omit<SidebarDividerProps, keyof ResponsiveProps>) => {
+  return (
+    <SidebarDividerStyled
+      data-testid={dataTestId ?? 'sidebar-divider'}
+      style={style}
+      {...rest}
+    />
+  );
+};
+
+SidebarDividerBase.displayName = 'Sidebar.Divider';
+
+export const SidebarDivider = withResponsive(SidebarDividerBase);

--- a/packages/react-packages/sidebar/src/components/SidebarDivider/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarDivider/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarDivider';

--- a/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.styled.ts
@@ -1,0 +1,237 @@
+import styled from '@emotion/styled';
+
+import { Typography } from '@dt-dds/react-typography';
+import { CustomTheme as Theme } from '@dt-dds/themes';
+
+import {
+  SIDEBAR_DEFAULT_TRANSITION,
+  SIDEBAR_WIDTH_MAX_TEXT_LENGTH,
+} from '../../constants';
+
+import type { SectionVariant } from '../../types';
+
+export const SidebarItemStyled = styled.li`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+export const SidebarItemHeaderStyled = styled.div<{
+  isActive?: boolean;
+  isSidebarCollapsed?: boolean;
+  isInteractive?: boolean;
+  isNested?: boolean;
+  sectionVariant?: SectionVariant;
+}>`
+  ${({
+    theme,
+    isActive,
+    isSidebarCollapsed,
+    isInteractive = true,
+    isNested = false,
+    sectionVariant,
+  }) => {
+    const padding = isNested
+      ? `${theme.spacing.spacing_30} ${theme.spacing.spacing_80}`
+      : `${theme.spacing.spacing_30} ${theme.spacing.spacing_60}`;
+
+    // To compensate for the scrollbar width
+    const paddingRight = `${
+      isSidebarCollapsed ? 'auto' : theme.spacing.spacing_30
+    }`;
+
+    const justifyContent = `${isSidebarCollapsed ? 'center' : 'space-between'}`;
+
+    return `
+      cursor: ${isInteractive ? 'pointer' : 'default'};
+      display: flex;
+      align-items: center;
+      padding: ${padding};
+      padding-right: ${paddingRight};
+      color: ${
+        isActive ? theme.palette.accent.default : theme.palette.content.default
+      };
+      justify-content: ${justifyContent};
+
+      &[role="button"] {
+        justify-content: ${justifyContent};
+      }
+
+      ${
+        sectionVariant === 'default' &&
+        `
+        transition: ${SIDEBAR_DEFAULT_TRANSITION};
+
+        &:hover,
+        &:focus-visible,
+        &:active {
+          background-color: ${theme.palette.accent.light};
+        }
+      `
+      }
+    `;
+  }}
+`;
+
+// Item body (Sublist container)
+export const SidebarItemBodyStyled = styled.div<{
+  isExpanded: boolean;
+  isSidebarJustExpanded?: boolean;
+}>`
+  ${({ isExpanded, isSidebarJustExpanded }) => {
+    const shouldDelay = isSidebarJustExpanded && isExpanded;
+
+    return `
+      display: grid;
+      grid-template-rows: ${isExpanded ? '1fr' : '0fr'};
+      transition: ${SIDEBAR_DEFAULT_TRANSITION};
+      overflow: hidden;
+
+      & > * {
+        min-height: 0;
+        opacity: ${shouldDelay ? '0' : isExpanded ? '1' : '0'};
+        visibility: ${
+          shouldDelay ? 'hidden' : isExpanded ? 'visible' : 'hidden'
+        };
+        ${
+          shouldDelay
+            ? `
+          transition: none;
+          animation: fadeInDelayed 0s ease-in-out 0s forwards;
+          @keyframes fadeInDelayed {
+            from {
+              opacity: 0;
+              visibility: hidden;
+            }
+            to {
+              opacity: 1;
+              visibility: visible;
+            }
+          }
+        `
+            : `
+          transition: ${SIDEBAR_DEFAULT_TRANSITION};
+        `
+        }
+      }
+    `;
+  }}
+`;
+
+// Default Item link styles
+const defaultSidebarItemLinkStyles = ({
+  theme,
+  isActive,
+  isSidebarCollapsed,
+  sectionVariant,
+}: {
+  theme: Theme;
+  isActive?: boolean;
+  isSidebarCollapsed?: boolean;
+  isNested?: boolean;
+  sectionVariant?: SectionVariant;
+}) => `
+  display: flex;
+  align-items: center;
+  width: ${isSidebarCollapsed ? 'auto' : '100%'};
+  gap: ${theme.spacing.spacing_40};
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: ${SIDEBAR_DEFAULT_TRANSITION};
+
+  ${
+    sectionVariant === 'header'
+      ? `
+        justify-content: space-between;
+        flex-direction: row-reverse;
+
+        &:has(> :only-child:not(button)) {
+          flex-direction: row;
+        }
+
+        svg,
+        img {
+          max-height: 24px;
+          width: auto;
+        }
+      `
+      : ''
+  }
+  ${
+    isSidebarCollapsed
+      ? `
+        justify-content: center;
+        padding: ${theme.spacing.spacing_10};
+      `
+      : ''
+  }
+
+  > i:first-of-type {
+    opacity: 1;
+    visibility: visible;
+    color: ${
+      isActive ? theme.palette.accent.default : theme.palette.content.dark
+    };
+
+    transition: ${SIDEBAR_DEFAULT_TRANSITION};
+  }
+
+  &:hover,
+  &:focus-visible,
+  &:active,
+  &:hover > i:first-of-type {
+    color: ${theme.palette.accent.default};
+  }
+`;
+
+export const SidebarItemLinkStyled = styled(Typography)<{
+  isActive?: boolean;
+  isSidebarCollapsed?: boolean;
+  isDynamicLink?: boolean;
+  isNested?: boolean;
+  sectionVariant?: SectionVariant;
+}>`
+  ${({
+    theme,
+    isActive,
+    isSidebarCollapsed,
+    isDynamicLink,
+    isNested,
+    sectionVariant,
+  }) =>
+    isDynamicLink
+      ? `
+      > a,
+      > *[href] {
+        ${defaultSidebarItemLinkStyles({
+          theme,
+          isActive,
+          isSidebarCollapsed,
+          isNested,
+          sectionVariant,
+        })}
+      }
+    `
+      : defaultSidebarItemLinkStyles({
+          theme,
+          isActive,
+          isSidebarCollapsed,
+          isNested,
+          sectionVariant,
+        })}
+`;
+
+// Item text content wrapper
+export const SidebarItemTextContent = styled.span<{
+  isSidebarCollapsed?: boolean;
+}>`
+  ${({ isSidebarCollapsed }) => `
+    max-width: ${SIDEBAR_WIDTH_MAX_TEXT_LENGTH}px;
+    opacity: ${isSidebarCollapsed ? '0' : '1'};
+    visibility: ${isSidebarCollapsed ? 'hidden' : 'visible'};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.test.tsx
@@ -1,0 +1,374 @@
+import React from 'react';
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
+
+import { Sidebar, type SidebarProps } from '../../Sidebar';
+import { SidebarSubList } from '../SidebarSubList';
+
+describe('<SidebarItem /> component', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  const renderItem = (
+    props: Partial<React.ComponentProps<typeof Sidebar.Item>> = {},
+    sidebarOverrides: Partial<SidebarProps> = {}
+  ) => {
+    const { children, ...rest } = props;
+    return render(
+      <ProvidedSidebar isExpanded {...sidebarOverrides}>
+        <Sidebar.Item {...(rest as React.ComponentProps<typeof Sidebar.Item>)}>
+          {children ?? null}
+        </Sidebar.Item>
+      </ProvidedSidebar>
+    );
+  };
+
+  const renderWithSubList = (
+    props?: Partial<React.ComponentProps<typeof Sidebar.Item>>,
+    sidebarOverrides?: Partial<SidebarProps>
+  ) => {
+    const { children, ...rest } = props ?? {};
+    const defaultChildren = (
+      <>
+        <span>Main Item</span>
+        <SidebarSubList>
+          <Sidebar.Item>Sub Item</Sidebar.Item>
+        </SidebarSubList>
+      </>
+    );
+
+    return renderItem(
+      {
+        ...rest,
+        children: children ?? defaultChildren,
+      },
+      sidebarOverrides
+    );
+  };
+
+  const getDisclosureElements = () => {
+    const parent = screen
+      .getAllByTestId('sidebar-item')
+      .find((item) => item.querySelector('[role="button"]'));
+
+    if (!parent) {
+      throw new Error('Expected disclosure parent element');
+    }
+
+    const header = parent.querySelector('[role="button"]') as HTMLElement;
+    const body = parent.querySelector('[aria-hidden]') as HTMLElement | null;
+    const toggleButton = parent.querySelector(
+      'button[aria-label]'
+    ) as HTMLElement | null;
+
+    return { parent, header, body, toggleButton };
+  };
+
+  const setLocationPath = (pathname: string) => {
+    window.history.replaceState({}, '', pathname);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
+  beforeEach(() => {
+    setLocationPath('/');
+  });
+
+  describe('Basic rendering', () => {
+    it('renders content inside a list item', () => {
+      renderItem({ children: 'Dashboard' });
+
+      const item = screen.getByTestId('sidebar-item');
+      expect(item.tagName).toBe('LI');
+      expect(item).toHaveTextContent('Dashboard');
+    });
+  });
+
+  describe('Link behavior', () => {
+    it('renders an anchor when href is provided', () => {
+      renderItem({ href: '/reports', children: 'Reports' });
+
+      const link = screen.getByRole('link', { name: 'Reports' });
+      expect(link).toHaveAttribute('href', '/reports');
+    });
+
+    it('supports custom link components', () => {
+      const MockLink = ({
+        href,
+        children,
+      }: {
+        href: string;
+        children: React.ReactNode;
+      }) => <a href={href}>{children}</a>;
+
+      renderItem({
+        children: <MockLink href='/about'>About</MockLink>,
+      });
+
+      const link = screen.getByRole('link', { name: 'About' });
+      expect(link).toHaveAttribute('href', '/about');
+    });
+
+    it('handles invalid href gracefully', () => {
+      renderItem({ href: 'invalid', children: 'Broken Link' });
+
+      const link = screen.getByRole('link', { name: 'Broken Link' });
+      expect(link).toBeInTheDocument();
+    });
+  });
+
+  describe('Disclosure behavior', () => {
+    it('toggles via header click and keyboard', () => {
+      renderWithSubList();
+      const { header, body } = getDisclosureElements();
+
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+      expect(body).toHaveAttribute('aria-hidden', 'true');
+
+      fireEvent.click(header);
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+      expect(body).toHaveAttribute('aria-hidden', 'false');
+
+      fireEvent.keyDown(header, { key: ' ' });
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ignores link interactions for toggling', () => {
+      setLocationPath('/elsewhere');
+      renderWithSubList({
+        href: '/dashboard',
+      });
+
+      const { header, parent } = getDisclosureElements();
+      const link = parent.querySelector('a') as HTMLElement;
+
+      fireEvent.click(link);
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.keyDown(link, { key: 'Enter' });
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('toggle button responds to click and keyboard', () => {
+      renderWithSubList();
+      const { header, toggleButton } = getDisclosureElements();
+      expect(toggleButton).toBeTruthy();
+
+      fireEvent.click(toggleButton!);
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.keyDown(toggleButton!, { key: 'Enter' });
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('invokes onToggle callback with the latest state', () => {
+      const onToggle = jest.fn();
+      renderWithSubList({ onToggle });
+      const { header } = getDisclosureElements();
+
+      fireEvent.click(header);
+      fireEvent.click(header);
+
+      expect(onToggle).toHaveBeenNthCalledWith(1, true);
+      expect(onToggle).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it('respects defaultExpanded prop', () => {
+      renderWithSubList({ defaultExpanded: true });
+      const { header } = getDisclosureElements();
+
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('auto-expands when href is active and remains collapsible', () => {
+      setLocationPath('/dashboard');
+      renderWithSubList({ href: '/dashboard' });
+
+      const { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.click(header);
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('auto-expands when descendant is active and remains collapsible', () => {
+      setLocationPath('/nested');
+      renderWithSubList({
+        children: (
+          <>
+            <span>Parent</span>
+            <SidebarSubList>
+              <Sidebar.Item href='/nested'>Nested Item</Sidebar.Item>
+            </SidebarSubList>
+          </>
+        ),
+      });
+
+      const { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.click(header);
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('renders only icons and hides sublists when desktop collapsed', () => {
+      renderWithSubList(
+        {
+          href: '/reports',
+          children: (
+            <>
+              <Icon code='date_range' />
+              <span>Reports</span>
+              <SidebarSubList>
+                <Sidebar.Item>Should not show</Sidebar.Item>
+              </SidebarSubList>
+            </>
+          ),
+        },
+        { isExpanded: false }
+      );
+
+      expect(screen.queryByText('Reports')).toBeNull();
+      expect(screen.queryByText('Should not show')).toBeNull();
+      expect(screen.queryByTestId('sidebar-sub-list')).toBeNull();
+      expect(screen.getAllByTestId('icon').length).toBeGreaterThan(0);
+    });
+
+    it('renders icon from custom link sibling after item with SubList when desktop collapsed', () => {
+      const MockLink = ({
+        href,
+        children,
+      }: {
+        href: string;
+        children: React.ReactNode;
+      }) => <a href={href}>{children}</a>;
+
+      const { container } = render(
+        <ProvidedSidebar isExpanded={false}>
+          <Sidebar.Section title='Test Section'>
+            <Sidebar.Item>
+              Another Item list
+              <SidebarSubList>
+                <Sidebar.Item>
+                  <p>Another Sub Item</p>
+                </Sidebar.Item>
+              </SidebarSubList>
+            </Sidebar.Item>
+            <Sidebar.Item>
+              <MockLink href='/dashboard'>
+                <Icon code='dashboard' />
+                Dashboard
+              </MockLink>
+            </Sidebar.Item>
+          </Sidebar.Section>
+        </ProvidedSidebar>
+      );
+
+      const items = container.querySelectorAll('[data-testid="sidebar-item"]');
+      expect(items.length).toBe(1);
+
+      const icons = screen.getAllByTestId('icon');
+      const dashboardIcon = icons.find(
+        (icon) => icon.textContent === 'dashboard'
+      );
+      expect(dashboardIcon).toBeInTheDocument();
+
+      expect(screen.queryByText('Dashboard')).toBeNull();
+      expect(screen.queryByText('Another Item list')).toBeNull();
+    });
+
+    it('expands when navigation activates the item', () => {
+      renderWithSubList({ href: '/reports' });
+      let { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+
+      act(() => setLocationPath('/reports'));
+      ({ header } = getDisclosureElements());
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('recognizes faux SubList elements with displayName', () => {
+      const FauxSubListWithDisplayName = ({
+        children,
+      }: {
+        children: React.ReactNode;
+      }) => <ul>{children}</ul>;
+      FauxSubListWithDisplayName.displayName = 'SidebarSubList';
+
+      renderWithSubList({
+        children: (
+          <>
+            <span>Custom SubList</span>
+            <FauxSubListWithDisplayName>
+              <Sidebar.Item>Inside Faux List</Sidebar.Item>
+            </FauxSubListWithDisplayName>
+          </>
+        ),
+      });
+
+      const { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('detects Sidebar.Item descendants even without displayName', () => {
+      const originalDisplayName = Sidebar.Item.displayName as
+        | string
+        | undefined;
+      Sidebar.Item.displayName = '';
+
+      setLocationPath('/nested');
+      renderWithSubList({
+        children: (
+          <>
+            <span>Parent</span>
+            <SidebarSubList>
+              <Sidebar.Item href='/nested'>Nested Item</Sidebar.Item>
+            </SidebarSubList>
+          </>
+        ),
+      });
+
+      const { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+
+      Sidebar.Item.displayName = originalDisplayName ?? 'SidebarItem';
+    });
+
+    it('respects controlled expanded prop', () => {
+      const { rerender } = renderWithSubList({ expanded: false });
+      let { header } = getDisclosureElements();
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+
+      rerender(
+        <ProvidedSidebar isExpanded>
+          <Sidebar.Item expanded>
+            <>
+              <span>Main Item</span>
+              <SidebarSubList>
+                <Sidebar.Item>Sub Item</Sidebar.Item>
+              </SidebarSubList>
+            </>
+          </Sidebar.Item>
+        </ProvidedSidebar>
+      );
+
+      ({ header } = getDisclosureElements());
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('Context requirement', () => {
+    it('throws when used outside Sidebar context', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      expect(() => {
+        render(<Sidebar.Item>Item</Sidebar.Item>);
+      }).toThrow('Sidebar compound components must be used within Sidebar');
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarItem/SidebarItem.tsx
@@ -1,0 +1,255 @@
+import {
+  HTMLAttributes,
+  ReactNode,
+  useState,
+  useMemo,
+  useId,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+} from 'react';
+
+import { Icon } from '@dt-dds/react-icon';
+import { IconButton } from '@dt-dds/react-icon-button';
+
+import {
+  SidebarItemStyled,
+  SidebarItemHeaderStyled,
+  SidebarItemBodyStyled,
+} from './SidebarItem.styled';
+import {
+  useSectionContext,
+  useSidebarContext,
+  useSubListContext,
+} from '../../context';
+import { useLocationPath, useDisclosureState } from '../../hooks';
+import {
+  isCurrentUrl,
+  partitionChildren,
+  containsActiveSidebarItem,
+  isLinkTarget,
+  renderContent,
+} from '../../utils';
+
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarItemProps
+  extends BaseProps,
+    Omit<HTMLAttributes<HTMLLIElement>, 'onClick'> {
+  href?: string;
+  defaultExpanded?: boolean;
+  expanded?: boolean;
+  onToggle?: (expanded: boolean) => void;
+  children: ReactNode;
+}
+
+export const SidebarItem = ({
+  href,
+  defaultExpanded = false,
+  expanded: controlledExpanded,
+  onToggle,
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: SidebarItemProps) => {
+  const { isExpanded: isSidebarExpanded, isMobile } = useSidebarContext();
+  const sectionVariant = useSectionContext();
+  const isNested = useSubListContext();
+  const collapseToIcons = !isMobile && !isSidebarExpanded;
+
+  const [isSidebarJustExpanded, setIsSidebarJustExpanded] = useState(false);
+  const prevCollapseToIcons = useRef(collapseToIcons);
+
+  useEffect(() => {
+    if (prevCollapseToIcons.current && !collapseToIcons) {
+      setIsSidebarJustExpanded(true);
+
+      const timeout = setTimeout(() => {
+        setIsSidebarJustExpanded(false);
+      }, 1000);
+      return () => clearTimeout(timeout);
+    }
+    prevCollapseToIcons.current = collapseToIcons;
+  }, [collapseToIcons]);
+
+  const { subList, otherChildren } = useMemo(
+    () => partitionChildren(children),
+    [children]
+  );
+
+  const currentPath = useLocationPath();
+
+  const isActive = useMemo(
+    () => isCurrentUrl(href, currentPath),
+    [href, currentPath]
+  );
+
+  const hasActiveDescendant = useMemo(() => {
+    if (!subList.length) return false;
+    return subList.some((node) =>
+      containsActiveSidebarItem(node, currentPath, isCurrentUrl)
+    );
+  }, [subList, currentPath]);
+
+  const shouldAutoExpand =
+    (isActive && subList.length > 0) || hasActiveDescendant;
+  const autoExpandKey = shouldAutoExpand
+    ? [href ?? '', currentPath, String(hasActiveDescendant)].join('|')
+    : null;
+
+  const { expanded, toggle } = useDisclosureState({
+    controlledExpanded,
+    defaultExpanded: defaultExpanded || shouldAutoExpand,
+    onToggle,
+    shouldAutoExpand,
+    autoExpandKey,
+  });
+
+  const submenuId = useId();
+  const headerId = useId();
+  const showDisclosure = subList.length > 0 && !collapseToIcons;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isLinkTarget(event.target)) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  const handleHeaderClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isLinkTarget(event.target)) {
+      return;
+    }
+    toggle();
+  };
+
+  const handleToggleButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.stopPropagation();
+    toggle();
+  };
+
+  const handleToggleButtonKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>
+  ) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+      toggle();
+    }
+  };
+
+  if (subList.length > 0) {
+    const toggleIconCode = expanded
+      ? 'keyboard_arrow_up'
+      : 'keyboard_arrow_down';
+
+    const headerContent = renderContent(
+      otherChildren,
+      href,
+      isActive,
+      collapseToIcons,
+      isNested,
+      sectionVariant
+    );
+
+    if (collapseToIcons && !headerContent) {
+      return null;
+    }
+
+    return (
+      <SidebarItemStyled
+        as='li'
+        data-testid={dataTestId ?? 'sidebar-item'}
+        style={style}
+        {...rest}
+      >
+        <SidebarItemHeaderStyled
+          aria-controls={showDisclosure ? submenuId : undefined}
+          aria-expanded={showDisclosure ? expanded : undefined}
+          id={`header-${headerId}`}
+          isActive={isActive}
+          isInteractive={showDisclosure}
+          isNested={isNested}
+          isSidebarCollapsed={collapseToIcons}
+          onClick={showDisclosure ? handleHeaderClick : undefined}
+          onKeyDown={showDisclosure ? handleKeyDown : undefined}
+          role={showDisclosure ? 'button' : undefined}
+          sectionVariant={sectionVariant}
+          tabIndex={showDisclosure ? 0 : undefined}
+        >
+          {headerContent}
+          {showDisclosure ? (
+            <IconButton
+              aria-controls={submenuId}
+              aria-expanded={expanded}
+              aria-label={expanded ? 'Collapse submenu' : 'Expand submenu'}
+              onClick={handleToggleButtonClick}
+              onKeyDown={handleToggleButtonKeyDown}
+              style={{
+                display: 'flex',
+                width: collapseToIcons ? 'auto' : '100%',
+                height: 'auto',
+                justifyContent: 'flex-end',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <Icon code={toggleIconCode} />
+            </IconButton>
+          ) : null}
+        </SidebarItemHeaderStyled>
+        {showDisclosure ? (
+          <SidebarItemBodyStyled
+            aria-hidden={!expanded}
+            aria-labelledby={headerId}
+            id={submenuId}
+            isExpanded={expanded}
+            isSidebarJustExpanded={isSidebarJustExpanded}
+          >
+            <div>{subList}</div>
+          </SidebarItemBodyStyled>
+        ) : null}
+      </SidebarItemStyled>
+    );
+  }
+
+  const headerContent = renderContent(
+    children,
+    href,
+    isActive,
+    collapseToIcons,
+    isNested,
+    sectionVariant
+  );
+
+  if (collapseToIcons && !headerContent) {
+    return null;
+  }
+
+  return (
+    <SidebarItemStyled
+      as='li'
+      data-testid={dataTestId ?? 'sidebar-item'}
+      style={style}
+      {...rest}
+    >
+      <SidebarItemHeaderStyled
+        isActive={isActive}
+        isInteractive={false}
+        isNested={isNested}
+        isSidebarCollapsed={collapseToIcons}
+        sectionVariant={sectionVariant}
+      >
+        {headerContent}
+      </SidebarItemHeaderStyled>
+    </SidebarItemStyled>
+  );
+};
+
+SidebarItem.displayName = 'SidebarItem';

--- a/packages/react-packages/sidebar/src/components/SidebarItem/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarItem/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarItem';

--- a/packages/react-packages/sidebar/src/components/SidebarSection/SidebarFooter.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/SidebarFooter.tsx
@@ -1,0 +1,53 @@
+import { HTMLAttributes, ReactNode, useMemo } from 'react';
+
+import {
+  type BaseProps,
+  type ResponsiveProps,
+  withResponsive,
+} from '@dt-dds/react-core';
+
+import { SidebarSectionRoot } from './SidebarSectionRoot.styled';
+import { SectionContext, useSidebarContext } from '../../context';
+import { hasFirstItemIcon } from '../../utils';
+
+export interface SidebarFooterProps
+  extends ResponsiveProps,
+    BaseProps,
+    HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+}
+
+const SidebarFooterBase = ({
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: Omit<SidebarFooterProps, keyof ResponsiveProps>) => {
+  const { isExpanded, isMobile } = useSidebarContext();
+  const isSidebarCollapsed = !isMobile && !isExpanded;
+
+  const firstItemHasIcon = useMemo(
+    () => hasFirstItemIcon(children),
+    [children]
+  );
+
+  return (
+    <SectionContext.Provider value={{ variant: 'footer' }}>
+      <SidebarSectionRoot
+        as='footer'
+        data-testid={dataTestId ?? 'sidebar-footer'}
+        firstItemHasIcon={firstItemHasIcon}
+        isSidebarCollapsed={isSidebarCollapsed}
+        style={style}
+        variant='footer'
+        {...rest}
+      >
+        <ul>{children}</ul>
+      </SidebarSectionRoot>
+    </SectionContext.Provider>
+  );
+};
+
+SidebarFooterBase.displayName = 'Sidebar.Footer';
+
+export const SidebarFooter = withResponsive(SidebarFooterBase);

--- a/packages/react-packages/sidebar/src/components/SidebarSection/SidebarHeader.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/SidebarHeader.tsx
@@ -1,0 +1,53 @@
+import { HTMLAttributes, ReactNode, useMemo } from 'react';
+
+import {
+  type ResponsiveProps,
+  type BaseProps,
+  withResponsive,
+} from '@dt-dds/react-core';
+
+import { SidebarSectionRoot } from './SidebarSectionRoot.styled';
+import { SectionContext, useSidebarContext } from '../../context';
+import { hasFirstItemIcon } from '../../utils';
+
+export interface SidebarHeaderProps
+  extends ResponsiveProps,
+    BaseProps,
+    HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+}
+
+const SidebarHeaderBase = ({
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: Omit<SidebarHeaderProps, keyof ResponsiveProps>) => {
+  const { isExpanded, isMobile } = useSidebarContext();
+  const isSidebarCollapsed = !isMobile && !isExpanded;
+
+  const firstItemHasIcon = useMemo(
+    () => hasFirstItemIcon(children),
+    [children]
+  );
+
+  return (
+    <SectionContext.Provider value={{ variant: 'header' }}>
+      <SidebarSectionRoot
+        as='header'
+        data-testid={dataTestId ?? 'sidebar-header'}
+        firstItemHasIcon={firstItemHasIcon}
+        isSidebarCollapsed={isSidebarCollapsed}
+        style={style}
+        variant='header'
+        {...rest}
+      >
+        <ul>{children}</ul>
+      </SidebarSectionRoot>
+    </SectionContext.Provider>
+  );
+};
+
+SidebarHeaderBase.displayName = 'Sidebar.Header';
+
+export const SidebarHeader = withResponsive(SidebarHeaderBase);

--- a/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSection.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSection.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
+
+import { Sidebar } from '../../Sidebar';
+
+describe('<SidebarSection /> component', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  it('should render section with title and children', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Section title='Test Section'>
+          <Sidebar.Item>Item</Sidebar.Item>
+        </Sidebar.Section>
+      </ProvidedSidebar>
+    );
+
+    const section = screen.getByTestId('sidebar-section');
+    expect(section.tagName).toBe('NAV');
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.getByText('Item')).toBeInTheDocument();
+  });
+
+  it('should detect icon when nested inside custom Link component', () => {
+    const MockLink = ({
+      href,
+      children,
+    }: {
+      href: string;
+      children: React.ReactNode;
+    }) => <a href={href}>{children}</a>;
+
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Section title='Test Section'>
+          <Sidebar.Item>
+            <MockLink href='/dashboard'>
+              <Icon code='dashboard' />
+              Dashboard
+            </MockLink>
+          </Sidebar.Item>
+        </Sidebar.Section>
+      </ProvidedSidebar>
+    );
+
+    const section = container.querySelector('[data-testid="sidebar-section"]');
+    // When icon is present (even nested in Link), section should be visible
+    expect(section).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should not detect icon in nested SubList items', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Section title='Test Section'>
+          <Sidebar.Item>
+            Another Item list
+            <Sidebar.SubList>
+              <Sidebar.Item>
+                <a href='/dashboard'>
+                  <Icon code='dashboard' />
+                  Dashboard
+                </a>
+              </Sidebar.Item>
+            </Sidebar.SubList>
+          </Sidebar.Item>
+        </Sidebar.Section>
+      </ProvidedSidebar>
+    );
+
+    const section = container.querySelector('[data-testid="sidebar-section"]');
+    // When first item has no icon (icon is only in nested SubList), section should be hidden when collapsed
+    expect(section).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('should show section when expanded even if first item has no icon', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Section title='Test Section'>
+          <Sidebar.Item>
+            Another Item list
+            <Sidebar.SubList>
+              <Sidebar.Item>
+                <a href='/dashboard'>
+                  <Icon code='dashboard' />
+                  Dashboard
+                </a>
+              </Sidebar.Item>
+            </Sidebar.SubList>
+          </Sidebar.Item>
+        </Sidebar.Section>
+      </ProvidedSidebar>
+    );
+
+    const section = container.querySelector('[data-testid="sidebar-section"]');
+    // When expanded, section should always show regardless of icons
+    expect(section).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should throw error when used outside Sidebar context', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => {
+      render(<Sidebar.Section title='Test'>Content</Sidebar.Section>);
+    }).toThrow('Sidebar compound components must be used within Sidebar');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('<SidebarHeader /> component', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  it('should render header with children', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Header>
+          <Sidebar.Item>Header Item</Sidebar.Item>
+        </Sidebar.Header>
+      </ProvidedSidebar>
+    );
+
+    const header = screen.getByTestId('sidebar-header');
+    expect(header.tagName).toBe('HEADER');
+    expect(screen.getByText('Header Item')).toBeInTheDocument();
+  });
+
+  it('should detect icon in first item', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Header>
+          <Sidebar.Item>
+            <Icon code='dashboard' />
+            Dashboard
+          </Sidebar.Item>
+        </Sidebar.Header>
+      </ProvidedSidebar>
+    );
+
+    const header = container.querySelector('[data-testid="sidebar-header"]');
+    expect(header).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should hide header when collapsed and first item has no icon', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Header>
+          <Sidebar.Item>No Icon Item</Sidebar.Item>
+        </Sidebar.Header>
+      </ProvidedSidebar>
+    );
+
+    const header = container.querySelector('[data-testid="sidebar-header"]');
+    expect(header).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('should show header when expanded even if first item has no icon', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Header>
+          <Sidebar.Item>No Icon Item</Sidebar.Item>
+        </Sidebar.Header>
+      </ProvidedSidebar>
+    );
+
+    const header = container.querySelector('[data-testid="sidebar-header"]');
+    expect(header).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should use custom dataTestId when provided', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Header dataTestId='custom-header'>
+          <Sidebar.Item>Item</Sidebar.Item>
+        </Sidebar.Header>
+      </ProvidedSidebar>
+    );
+
+    expect(screen.getByTestId('custom-header')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-header')).not.toBeInTheDocument();
+  });
+
+  it('should throw error when used outside Sidebar context', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => {
+      render(<Sidebar.Header>Content</Sidebar.Header>);
+    }).toThrow('Sidebar compound components must be used within Sidebar');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('<SidebarFooter /> component', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  it('should render footer with children', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Footer>
+          <Sidebar.Item>Footer Item</Sidebar.Item>
+        </Sidebar.Footer>
+      </ProvidedSidebar>
+    );
+
+    const footer = screen.getByTestId('sidebar-footer');
+    expect(footer.tagName).toBe('FOOTER');
+    expect(screen.getByText('Footer Item')).toBeInTheDocument();
+  });
+
+  it('should detect icon in first item', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Footer>
+          <Sidebar.Item>
+            <Icon code='settings' />
+            Settings
+          </Sidebar.Item>
+        </Sidebar.Footer>
+      </ProvidedSidebar>
+    );
+
+    const footer = container.querySelector('[data-testid="sidebar-footer"]');
+    expect(footer).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should hide footer when collapsed and first item has no icon', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded={false}>
+        <Sidebar.Footer>
+          <Sidebar.Item>No Icon Item</Sidebar.Item>
+        </Sidebar.Footer>
+      </ProvidedSidebar>
+    );
+
+    const footer = container.querySelector('[data-testid="sidebar-footer"]');
+    expect(footer).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('should show footer when expanded even if first item has no icon', () => {
+    const { container } = render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Footer>
+          <Sidebar.Item>No Icon Item</Sidebar.Item>
+        </Sidebar.Footer>
+      </ProvidedSidebar>
+    );
+
+    const footer = container.querySelector('[data-testid="sidebar-footer"]');
+    expect(footer).toHaveStyle({
+      display: 'flex',
+    });
+  });
+
+  it('should use custom dataTestId when provided', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Footer dataTestId='custom-footer'>
+          <Sidebar.Item>Item</Sidebar.Item>
+        </Sidebar.Footer>
+      </ProvidedSidebar>
+    );
+
+    expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-footer')).not.toBeInTheDocument();
+  });
+
+  it('should throw error when used outside Sidebar context', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => {
+      render(<Sidebar.Footer>Content</Sidebar.Footer>);
+    }).toThrow('Sidebar compound components must be used within Sidebar');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSection.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSection.tsx
@@ -1,0 +1,69 @@
+import { HTMLAttributes, ReactNode, useMemo } from 'react';
+
+import { useTheme } from '@emotion/react';
+
+import { Typography } from '@dt-dds/react-typography';
+
+import { SidebarSectionRoot } from './SidebarSectionRoot.styled';
+import { SectionContext, useSidebarContext } from '../../context';
+import { hasFirstItemIcon } from '../../utils';
+
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarSectionProps
+  extends BaseProps,
+    HTMLAttributes<HTMLElement> {
+  title?: string;
+  children: ReactNode;
+}
+
+export const SidebarSection = ({
+  title,
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: SidebarSectionProps) => {
+  const theme = useTheme();
+  const { isExpanded, isMobile } = useSidebarContext();
+  const isSidebarCollapsed = !isMobile && !isExpanded;
+  const shouldShowTitle = title && !isSidebarCollapsed;
+
+  const firstItemHasIcon = useMemo(
+    () => hasFirstItemIcon(children),
+    [children]
+  );
+
+  return (
+    <SectionContext.Provider value={{ variant: 'default' }}>
+      <SidebarSectionRoot
+        as='nav'
+        data-testid={dataTestId ?? 'sidebar-section'}
+        firstItemHasIcon={firstItemHasIcon}
+        isSidebarCollapsed={isSidebarCollapsed}
+        style={style}
+        variant='default'
+        {...rest}
+      >
+        {shouldShowTitle ? (
+          <Typography
+            color='content.dark'
+            element='h2'
+            fontStyles='bodySmBold'
+            style={{
+              padding: `${theme.spacing.spacing_50} ${theme.spacing.spacing_60}`,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textTransform: 'uppercase',
+            }}
+          >
+            {title}
+          </Typography>
+        ) : null}
+        <ul>{children}</ul>
+      </SidebarSectionRoot>
+    </SectionContext.Provider>
+  );
+};
+
+SidebarSection.displayName = 'Sidebar.Section';

--- a/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSectionRoot.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/SidebarSectionRoot.styled.ts
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+import {
+  SIDEBAR_HEADER_HEIGHT,
+  SIDEBAR_HEADER_HEIGHT_MOBILE,
+} from '../../constants';
+
+import type { SectionVariant } from '../../types';
+
+export const SidebarSectionRoot = styled.section<{
+  variant: SectionVariant;
+  firstItemHasIcon: boolean;
+  isSidebarCollapsed: boolean;
+}>`
+  ${({ theme, variant, isSidebarCollapsed, firstItemHasIcon }) => {
+    const shouldHide = isSidebarCollapsed && !firstItemHasIcon;
+
+    return `
+      display: ${shouldHide ? 'none' : 'flex'};
+      flex-direction: column;
+      margin: 0;
+      padding: ${theme.spacing.spacing_50} ${theme.spacing.spacing_0};
+      
+      ul {
+        display: flex;
+        flex-direction: column;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      ${
+        variant === 'header' &&
+        `
+        height: ${SIDEBAR_HEADER_HEIGHT}px;
+        justify-content: center;
+        overflow: hidden;
+
+        @media (min-width: ${theme.breakpoints.mq3}px) {
+          height: ${SIDEBAR_HEADER_HEIGHT_MOBILE}px;
+        }
+      `
+      }
+    `;
+  }}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarSection/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarSection/index.ts
@@ -1,0 +1,3 @@
+export * from './SidebarSection';
+export * from './SidebarHeader';
+export * from './SidebarFooter';

--- a/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.styled.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const SidebarSubListStyled = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+
+import { Sidebar } from '../../Sidebar';
+
+describe('<SidebarSubList /> component', () => {
+  const ProvidedSidebar = withProviders(Sidebar);
+
+  it('should render sublist with children', () => {
+    render(
+      <ProvidedSidebar isExpanded>
+        <Sidebar.Item>
+          <Sidebar.SubList>
+            <Sidebar.Item>Sub Item</Sidebar.Item>
+          </Sidebar.SubList>
+        </Sidebar.Item>
+      </ProvidedSidebar>
+    );
+
+    const subList = screen.getByTestId('sidebar-sub-list');
+    expect(subList.tagName).toBe('UL');
+    expect(subList).toHaveTextContent('Sub Item');
+  });
+
+  it('should throw error when used outside Sidebar context', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => {
+      render(
+        <Sidebar.SubList>
+          <Sidebar.Item>Item</Sidebar.Item>
+        </Sidebar.SubList>
+      );
+    }).toThrow('Sidebar compound components must be used within Sidebar');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarSubList/SidebarSubList.tsx
@@ -1,0 +1,36 @@
+import { HTMLAttributes, ReactNode } from 'react';
+
+import { SidebarSubListStyled } from './SidebarSubList.styled';
+import { useSidebarContext, SubListContext } from '../../context';
+
+import type { BaseProps } from '@dt-dds/react-core';
+
+export interface SidebarSubListProps
+  extends BaseProps,
+    HTMLAttributes<HTMLUListElement> {
+  children: ReactNode;
+}
+
+export const SidebarSubList = ({
+  children,
+  dataTestId,
+  style,
+  ...rest
+}: SidebarSubListProps) => {
+  useSidebarContext();
+
+  return (
+    <SubListContext.Provider value={{ isNested: true }}>
+      <SidebarSubListStyled
+        as='ul'
+        data-testid={dataTestId ?? 'sidebar-sub-list'}
+        style={style}
+        {...rest}
+      >
+        {children}
+      </SidebarSubListStyled>
+    </SubListContext.Provider>
+  );
+};
+
+SidebarSubList.displayName = 'SidebarSubList';

--- a/packages/react-packages/sidebar/src/components/SidebarSubList/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarSubList/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarSubList';

--- a/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.styled.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.styled.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import { IconButton } from '@dt-dds/react-icon-button';
+
+interface SidebarToggleStyledProps {
+  isSidebarCollapsed: boolean;
+}
+
+export const SidebarToggleStyled = styled(IconButton)<SidebarToggleStyledProps>`
+  ${({ isSidebarCollapsed }) => `
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    > i {
+      transform: ${isSidebarCollapsed ? 'rotate(180deg)' : ''};
+    }
+  `}
+`;

--- a/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.test.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+
+import { SidebarToggle } from './SidebarToggle';
+import { SidebarContextProvider, SidebarContextValue } from '../../context';
+
+describe('<SidebarToggle /> component', () => {
+  const ProvidedToggle = withProviders(SidebarToggle);
+
+  const defaultContext: SidebarContextValue = {
+    isExpanded: true,
+    isMobile: false,
+  };
+
+  const renderToggle = (
+    props = {},
+    contextValue: SidebarContextValue = defaultContext
+  ) => {
+    return render(
+      <SidebarContextProvider value={contextValue}>
+        <ProvidedToggle {...props} />
+      </SidebarContextProvider>
+    );
+  };
+
+  const getToggleButton = () =>
+    screen.getByRole('button', { name: 'Toggle sidebar navigation' });
+
+  it('renders toggle button with icon', () => {
+    renderToggle();
+    expect(getToggleButton()).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toHaveTextContent('menu_open');
+  });
+
+  it('sets aria-expanded to true when sidebar is expanded', () => {
+    renderToggle({}, { isExpanded: true, isMobile: false });
+    expect(getToggleButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('sets aria-expanded to false when sidebar is collapsed', () => {
+    renderToggle({}, { isExpanded: false, isMobile: false });
+    expect(getToggleButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  describe('click behavior', () => {
+    it('calls context onToggle when no onClick provided', () => {
+      const mockOnToggle = jest.fn();
+      renderToggle({}, { ...defaultContext, onToggle: mockOnToggle });
+
+      fireEvent.click(getToggleButton());
+
+      expect(mockOnToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClick when provided (overrides onToggle)', () => {
+      const mockOnClick = jest.fn();
+      const mockOnToggle = jest.fn();
+      renderToggle(
+        { onClick: mockOnClick },
+        { ...defaultContext, onToggle: mockOnToggle }
+      );
+
+      fireEvent.click(getToggleButton());
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(mockOnToggle).not.toHaveBeenCalled();
+    });
+
+    it('handles click gracefully when neither onClick nor onToggle available', () => {
+      renderToggle({}, { isExpanded: true, isMobile: false });
+
+      fireEvent.click(getToggleButton());
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.tsx
+++ b/packages/react-packages/sidebar/src/components/SidebarToggle/SidebarToggle.tsx
@@ -1,0 +1,28 @@
+import { Icon } from '@dt-dds/react-icon';
+
+import { SidebarToggleStyled } from './SidebarToggle.styled';
+import { useSidebarContext } from '../../context';
+
+export interface SidebarToggleProps {
+  onClick?: () => void;
+}
+
+export const SidebarToggle = ({ onClick }: SidebarToggleProps) => {
+  const { isExpanded, isMobile, onToggle } = useSidebarContext();
+  const isSidebarCollapsed = !isMobile && !isExpanded;
+
+  const handleClick = onClick ?? onToggle;
+
+  return (
+    <SidebarToggleStyled
+      aria-expanded={!isSidebarCollapsed}
+      aria-label='Toggle sidebar navigation'
+      isSidebarCollapsed={isSidebarCollapsed}
+      onClick={handleClick}
+    >
+      <Icon code='menu_open' />
+    </SidebarToggleStyled>
+  );
+};
+
+SidebarToggle.displayName = 'Sidebar.Toggle';

--- a/packages/react-packages/sidebar/src/components/SidebarToggle/index.ts
+++ b/packages/react-packages/sidebar/src/components/SidebarToggle/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarToggle';

--- a/packages/react-packages/sidebar/src/components/index.ts
+++ b/packages/react-packages/sidebar/src/components/index.ts
@@ -1,0 +1,7 @@
+export * from './SidebarBackdrop';
+export * from './SidebarDivider';
+export * from './SidebarSection';
+export * from './SidebarItem';
+export * from './SidebarSubList';
+export * from './SidebarContent';
+export * from './SidebarToggle';

--- a/packages/react-packages/sidebar/src/constants/index.ts
+++ b/packages/react-packages/sidebar/src/constants/index.ts
@@ -1,0 +1,17 @@
+export const SIDEBAR_WIDTH = 250;
+export const SIDEBAR_WIDTH_MAX_TEXT_LENGTH = 170;
+export const SIDEBAR_WIDTH_MINI = 70;
+
+export const SIDEBAR_HEADER_HEIGHT = 64;
+export const SIDEBAR_HEADER_HEIGHT_MOBILE = 72;
+
+export const SIDEBAR_DEFAULT_OFFSET_TOP = 0;
+export const SIDEBAR_DEFAULT_OFFSET_POSITION = 0;
+export const SIDEBAR_DEFAULT_PLACEMENT = 'left';
+export const SIDEBAR_MOBILE_PLACEMENT = 'right';
+
+export const SIDEBAR_BACKDROP_SHOW_DELAY = 50;
+export const SIDEBAR_BACKDROP_HIDE_DELAY = 200;
+
+// Should come from tokens in the future
+export const SIDEBAR_DEFAULT_TRANSITION = 'all 0.2s ease-in-out';

--- a/packages/react-packages/sidebar/src/context/SectionContext.tsx
+++ b/packages/react-packages/sidebar/src/context/SectionContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+import type { SectionVariant } from '../types';
+
+export interface SectionContextValue {
+  variant: SectionVariant;
+}
+
+export const SectionContext = createContext<SectionContextValue | null>(null);
+
+export const useSectionContext = (): SectionVariant => {
+  const context = useContext(SectionContext);
+  return context?.variant ?? 'default';
+};

--- a/packages/react-packages/sidebar/src/context/SidebarContext.tsx
+++ b/packages/react-packages/sidebar/src/context/SidebarContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, ReactNode } from 'react';
+
+export interface SidebarContextValue {
+  isExpanded: boolean;
+  isMobile: boolean;
+  onToggle?: () => void;
+}
+
+interface SidebarContextProviderProps {
+  value: SidebarContextValue;
+  children: ReactNode;
+}
+
+export const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+export const SidebarContextProvider = ({
+  value,
+  children,
+}: SidebarContextProviderProps) => {
+  return (
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
+  );
+};
+
+export const useSidebarContext = (): SidebarContextValue => {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error('Sidebar compound components must be used within Sidebar');
+  }
+  return context;
+};

--- a/packages/react-packages/sidebar/src/context/SubListContext.tsx
+++ b/packages/react-packages/sidebar/src/context/SubListContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+export interface SubListContextValue {
+  isNested: boolean;
+}
+
+export const SubListContext = createContext<SubListContextValue | null>(null);
+
+export const useSubListContext = (): boolean => {
+  const context = useContext(SubListContext);
+  return context?.isNested ?? false;
+};

--- a/packages/react-packages/sidebar/src/context/index.ts
+++ b/packages/react-packages/sidebar/src/context/index.ts
@@ -1,0 +1,3 @@
+export * from './SidebarContext';
+export * from './SectionContext';
+export * from './SubListContext';

--- a/packages/react-packages/sidebar/src/hooks/__tests__/useDisclosureState.test.tsx
+++ b/packages/react-packages/sidebar/src/hooks/__tests__/useDisclosureState.test.tsx
@@ -1,0 +1,299 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDisclosureState } from '../useDisclosureState';
+
+describe('useDisclosureState', () => {
+  describe('uncontrolled mode', () => {
+    it('initializes with defaultExpanded value', () => {
+      const { result } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: true,
+          shouldAutoExpand: false,
+          autoExpandKey: null,
+        })
+      );
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('toggles state when not controlled', () => {
+      const { result } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: false,
+          shouldAutoExpand: false,
+          autoExpandKey: null,
+        })
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.expanded).toBe(true);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('calls onToggle callback when provided', () => {
+      const onToggle = jest.fn();
+
+      const { result } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: false,
+          onToggle,
+          shouldAutoExpand: false,
+          autoExpandKey: null,
+        })
+      );
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(onToggle).toHaveBeenCalledWith(false);
+      expect(onToggle).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('uses controlledExpanded value when provided', () => {
+      const { result } = renderHook(
+        ({ controlledExpanded }) =>
+          useDisclosureState({
+            controlledExpanded,
+            defaultExpanded: false,
+            shouldAutoExpand: false,
+            autoExpandKey: null,
+          }),
+        {
+          initialProps: { controlledExpanded: true },
+        }
+      );
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('updates when controlledExpanded changes', () => {
+      const { result, rerender } = renderHook(
+        ({ controlledExpanded }) =>
+          useDisclosureState({
+            controlledExpanded,
+            defaultExpanded: false,
+            shouldAutoExpand: false,
+            autoExpandKey: null,
+          }),
+        {
+          initialProps: { controlledExpanded: false },
+        }
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      rerender({ controlledExpanded: true });
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('calls onToggle but does not update internal state when controlled', () => {
+      const onToggle = jest.fn();
+
+      const { result, rerender } = renderHook(
+        ({ controlledExpanded }) =>
+          useDisclosureState({
+            controlledExpanded,
+            defaultExpanded: false,
+            onToggle,
+            shouldAutoExpand: false,
+            autoExpandKey: null,
+          }),
+        {
+          initialProps: { controlledExpanded: false },
+        }
+      );
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+      // State should remain false until parent updates controlledExpanded
+      expect(result.current.expanded).toBe(false);
+
+      rerender({ controlledExpanded: true });
+
+      expect(result.current.expanded).toBe(true);
+    });
+  });
+
+  describe('auto-expansion', () => {
+    it('auto-expands when shouldAutoExpand is true and autoExpandKey changes', () => {
+      const { result, rerender } = renderHook(
+        ({ autoExpandKey }) =>
+          useDisclosureState({
+            defaultExpanded: false,
+            shouldAutoExpand: true,
+            autoExpandKey,
+          }),
+        {
+          initialProps: { autoExpandKey: 'key1' },
+        }
+      );
+
+      // On initial render, if defaultExpanded is false, it stays false
+      // Auto-expansion only happens when the key changes
+      expect(result.current.expanded).toBe(false);
+
+      // New key should trigger expansion (key changed)
+      rerender({ autoExpandKey: 'key2' });
+      expect(result.current.expanded).toBe(true);
+
+      // Same key should not trigger expansion again
+      rerender({ autoExpandKey: 'key2' });
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('does not auto-expand when shouldAutoExpand is false', () => {
+      const { result, rerender } = renderHook(
+        ({ autoExpandKey }) =>
+          useDisclosureState({
+            defaultExpanded: false,
+            shouldAutoExpand: false,
+            autoExpandKey,
+          }),
+        {
+          initialProps: { autoExpandKey: 'key1' },
+        }
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      rerender({ autoExpandKey: 'key2' });
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('does not auto-expand when controlled', () => {
+      const { result, rerender } = renderHook(
+        ({ autoExpandKey }) =>
+          useDisclosureState({
+            controlledExpanded: false,
+            defaultExpanded: false,
+            shouldAutoExpand: true,
+            autoExpandKey,
+          }),
+        {
+          initialProps: { autoExpandKey: 'key1' },
+        }
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      rerender({ autoExpandKey: 'key2' });
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('resets lastAutoExpandKey when shouldAutoExpand becomes false', () => {
+      const { result, rerender } = renderHook(
+        ({ shouldAutoExpand, autoExpandKey }) =>
+          useDisclosureState({
+            defaultExpanded: false,
+            shouldAutoExpand,
+            autoExpandKey,
+          }),
+        {
+          initialProps: { shouldAutoExpand: true, autoExpandKey: 'key1' },
+        }
+      );
+
+      // Initial render with defaultExpanded=false stays false
+      expect(result.current.expanded).toBe(false);
+
+      // Change key to trigger expansion
+      rerender({ shouldAutoExpand: true, autoExpandKey: 'key2' });
+      expect(result.current.expanded).toBe(true);
+
+      // Disable auto-expand
+      rerender({ shouldAutoExpand: false, autoExpandKey: 'key2' });
+      expect(result.current.expanded).toBe(true); // State doesn't change, just tracking resets
+
+      // Re-enable with new key - should expand because lastAutoExpandKey was reset
+      rerender({ shouldAutoExpand: true, autoExpandKey: 'key3' });
+      expect(result.current.expanded).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles null autoExpandKey', () => {
+      const { result } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: false,
+          shouldAutoExpand: true,
+          autoExpandKey: null,
+        })
+      );
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('converts falsy expanded values to false', () => {
+      const { result } = renderHook(
+        ({ controlledExpanded }) =>
+          useDisclosureState({
+            controlledExpanded,
+            defaultExpanded: false,
+            shouldAutoExpand: false,
+            autoExpandKey: null,
+          }),
+        {
+          initialProps: {
+            controlledExpanded: undefined,
+          },
+        }
+      );
+
+      // When controlledExpanded is undefined, it uses internal state
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('maintains independent state across multiple hook instances', () => {
+      const { result: result1 } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: false,
+          shouldAutoExpand: false,
+          autoExpandKey: null,
+        })
+      );
+
+      const { result: result2 } = renderHook(() =>
+        useDisclosureState({
+          defaultExpanded: true,
+          shouldAutoExpand: false,
+          autoExpandKey: null,
+        })
+      );
+
+      expect(result1.current.expanded).toBe(false);
+      expect(result2.current.expanded).toBe(true);
+
+      act(() => {
+        result1.current.toggle();
+      });
+
+      expect(result1.current.expanded).toBe(true);
+      expect(result2.current.expanded).toBe(true);
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/hooks/__tests__/useLocationPath.test.tsx
+++ b/packages/react-packages/sidebar/src/hooks/__tests__/useLocationPath.test.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook } from '@testing-library/react';
+
+import * as urlUtils from '../../utils/urlUtils';
+import { useLocationPath } from '../useLocationPath';
+
+describe('useLocationPath', () => {
+  let locationMock: Location;
+
+  beforeEach(() => {
+    // Create a mock location object
+    locationMock = {
+      pathname: '/',
+      href: 'http://localhost/',
+      origin: 'http://localhost',
+    } as Location;
+
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('returns current pathname on initial render', () => {
+    locationMock.pathname = '/dashboard';
+
+    const { result } = renderHook(() => useLocationPath());
+
+    expect(result.current).toBe('/dashboard');
+  });
+
+  it('updates when popstate event fires', () => {
+    const { result } = renderHook(() => useLocationPath());
+
+    expect(result.current).toBe('/');
+
+    act(() => {
+      locationMock.pathname = '/settings';
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(result.current).toBe('/settings');
+  });
+
+  it('updates when hashchange event fires', () => {
+    const { result } = renderHook(() => useLocationPath());
+
+    expect(result.current).toBe('/');
+
+    act(() => {
+      locationMock.pathname = '/dashboard';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    expect(result.current).toBe('/dashboard');
+  });
+
+  it('handles multiple location changes', () => {
+    const { result } = renderHook(() => useLocationPath());
+
+    expect(result.current).toBe('/');
+
+    act(() => {
+      locationMock.pathname = '/page1';
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(result.current).toBe('/page1');
+
+    act(() => {
+      locationMock.pathname = '/page2';
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(result.current).toBe('/page2');
+  });
+
+  it('cleans up event listeners on unmount', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useLocationPath());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'popstate',
+      expect.any(Function)
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'hashchange',
+      expect.any(Function)
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'popstate',
+      expect.any(Function)
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'hashchange',
+      expect.any(Function)
+    );
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('handles SSR environment gracefully', () => {
+    const originalWindow = globalThis.window;
+
+    // Mock getCurrentPath to return empty string (SSR behavior)
+    const getCurrentPathSpy = jest
+      .spyOn(urlUtils, 'getCurrentPath')
+      .mockReturnValue('');
+
+    const { result } = renderHook(() => useLocationPath());
+
+    // Should return empty string in SSR
+    expect(result.current).toBe('');
+
+    // Restore
+    getCurrentPathSpy.mockRestore();
+    globalThis.window = originalWindow;
+  });
+
+  it('maintains independent state across multiple hook instances', () => {
+    const { result: result1 } = renderHook(() => useLocationPath());
+    const { result: result2 } = renderHook(() => useLocationPath());
+
+    expect(result1.current).toBe('/');
+    expect(result2.current).toBe('/');
+
+    act(() => {
+      locationMock.pathname = '/page1';
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    // Both should update independently
+    expect(result1.current).toBe('/page1');
+    expect(result2.current).toBe('/page1');
+  });
+});

--- a/packages/react-packages/sidebar/src/hooks/__tests__/useSidebar.test.tsx
+++ b/packages/react-packages/sidebar/src/hooks/__tests__/useSidebar.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSidebar } from '../useSidebar';
+
+describe('useSidebar', () => {
+  it('initializes with default state (false) when no options provided', () => {
+    const { result } = renderHook(() => useSidebar());
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it('initializes with provided isExpanded option', () => {
+    const { result } = renderHook(() => useSidebar({ isExpanded: true }));
+    expect(result.current.isExpanded).toBe(true);
+  });
+
+  it('toggles sidebar state', () => {
+    const { result } = renderHook(() => useSidebar({ isExpanded: false }));
+
+    expect(result.current.isExpanded).toBe(false);
+
+    act(() => result.current.toggleSidebar());
+    expect(result.current.isExpanded).toBe(true);
+
+    act(() => result.current.toggleSidebar());
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it('allows direct state setting via setIsExpanded', () => {
+    const { result } = renderHook(() => useSidebar({ isExpanded: false }));
+
+    expect(result.current.isExpanded).toBe(false);
+
+    act(() => result.current.setIsExpanded(true));
+    expect(result.current.isExpanded).toBe(true);
+
+    act(() => result.current.setIsExpanded(false));
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it('returns isExpanded, setIsExpanded, and toggleSidebar', () => {
+    const { result } = renderHook(() => useSidebar());
+
+    expect(result.current).toHaveProperty('isExpanded');
+    expect(result.current).toHaveProperty('setIsExpanded');
+    expect(result.current).toHaveProperty('toggleSidebar');
+    expect(typeof result.current.setIsExpanded).toBe('function');
+    expect(typeof result.current.toggleSidebar).toBe('function');
+  });
+
+  it('maintains independent state across multiple hook instances', () => {
+    const { result: result1 } = renderHook(() =>
+      useSidebar({ isExpanded: true })
+    );
+    const { result: result2 } = renderHook(() =>
+      useSidebar({ isExpanded: false })
+    );
+
+    expect(result1.current.isExpanded).toBe(true);
+    expect(result2.current.isExpanded).toBe(false);
+
+    act(() => result1.current.toggleSidebar());
+    act(() => result2.current.toggleSidebar());
+
+    expect(result1.current.isExpanded).toBe(false);
+    expect(result2.current.isExpanded).toBe(true);
+  });
+});

--- a/packages/react-packages/sidebar/src/hooks/index.ts
+++ b/packages/react-packages/sidebar/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export { type UseSidebarOptions, useSidebar } from './useSidebar';
+export { useLocationPath } from './useLocationPath';
+export { useDisclosureState } from './useDisclosureState';

--- a/packages/react-packages/sidebar/src/hooks/useDisclosureState.ts
+++ b/packages/react-packages/sidebar/src/hooks/useDisclosureState.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseDisclosureStateOptions {
+  controlledExpanded?: boolean;
+  defaultExpanded: boolean;
+  onToggle?: (expanded: boolean) => void;
+  shouldAutoExpand: boolean;
+  autoExpandKey: string | null;
+}
+
+// Determines if auto-expand should trigger for a new key.
+const shouldTriggerAutoExpand = (
+  isControlled: boolean,
+  shouldAutoExpand: boolean,
+  autoExpandKey: string | null,
+  lastKey: string | null
+): boolean =>
+  !isControlled &&
+  shouldAutoExpand &&
+  !!autoExpandKey &&
+  lastKey !== autoExpandKey;
+
+// Hook to manage sidebar item expand/collapse (disclosure) state.
+export const useDisclosureState = ({
+  controlledExpanded,
+  defaultExpanded,
+  onToggle,
+  shouldAutoExpand,
+  autoExpandKey,
+}: UseDisclosureStateOptions): {
+  expanded: boolean;
+  toggle: () => void;
+} => {
+  const isControlled = controlledExpanded !== undefined;
+
+  const [internalExpanded, setInternalExpanded] = useState(
+    () => defaultExpanded
+  );
+
+  const lastAutoExpandKey = useRef<string | null>(
+    shouldAutoExpand ? autoExpandKey : null
+  );
+
+  // Auto-expand when URL changes to match this item or its descendants
+  useEffect(() => {
+    const shouldTrigger = shouldTriggerAutoExpand(
+      isControlled,
+      shouldAutoExpand,
+      autoExpandKey,
+      lastAutoExpandKey.current
+    );
+
+    if (!shouldAutoExpand) {
+      lastAutoExpandKey.current = null;
+      return;
+    }
+
+    if (shouldTrigger) {
+      setInternalExpanded(true);
+      lastAutoExpandKey.current = autoExpandKey;
+    }
+  }, [autoExpandKey, isControlled, shouldAutoExpand]);
+
+  const expanded = isControlled ? controlledExpanded : internalExpanded;
+
+  const toggle = useCallback(() => {
+    const next = !expanded;
+    if (!isControlled) {
+      setInternalExpanded(next);
+    }
+
+    onToggle?.(next);
+  }, [expanded, isControlled, onToggle]);
+
+  return {
+    expanded: !!expanded,
+    toggle,
+  };
+};

--- a/packages/react-packages/sidebar/src/hooks/useLocationPath.ts
+++ b/packages/react-packages/sidebar/src/hooks/useLocationPath.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+import { getCurrentPath } from '../utils/urlUtils';
+
+// Hook to track the current URL pathname
+export const useLocationPath = () => {
+  const [path, setPath] = useState(() => getCurrentPath());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleLocationChange = () => {
+      setPath(getCurrentPath());
+    };
+
+    window.addEventListener('popstate', handleLocationChange);
+    window.addEventListener('hashchange', handleLocationChange);
+
+    return () => {
+      window.removeEventListener('popstate', handleLocationChange);
+      window.removeEventListener('hashchange', handleLocationChange);
+    };
+  }, []);
+
+  return path;
+};

--- a/packages/react-packages/sidebar/src/hooks/useSidebar.tsx
+++ b/packages/react-packages/sidebar/src/hooks/useSidebar.tsx
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+
+export interface UseSidebarOptions {
+  isExpanded?: boolean;
+}
+
+export const useSidebar = (
+  options: UseSidebarOptions = {}
+): {
+  isExpanded: boolean;
+  setIsExpanded: (expanded: boolean) => void;
+  toggleSidebar: () => void;
+} => {
+  const { isExpanded: initialExpanded = false } = options;
+
+  const [isExpanded, setIsExpanded] = useState(initialExpanded);
+
+  const toggleSidebar = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  return {
+    isExpanded,
+    setIsExpanded,
+    toggleSidebar,
+  };
+};

--- a/packages/react-packages/sidebar/src/index.ts
+++ b/packages/react-packages/sidebar/src/index.ts
@@ -1,0 +1,2 @@
+export * from './Sidebar';
+export { type UseSidebarOptions, useSidebar } from './hooks/useSidebar';

--- a/packages/react-packages/sidebar/src/types/index.ts
+++ b/packages/react-packages/sidebar/src/types/index.ts
@@ -1,0 +1,3 @@
+export type SidebarPlacement = 'left' | 'right';
+
+export type SectionVariant = 'default' | 'header' | 'footer';

--- a/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemContent.test.tsx
+++ b/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemContent.test.tsx
@@ -1,0 +1,263 @@
+import React, { ReactElement } from 'react';
+
+import { render } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
+
+import {
+  createLinkStyledProps,
+  createLinkWrapperProps,
+  createWrapperProps,
+  extractTextContent,
+  partitionIconAndContent,
+  wrapTextContent,
+  wrapWithTooltip,
+} from '../sidebarItemContent';
+
+describe('sidebarItemContent', () => {
+  describe('extractTextContent', () => {
+    it('extracts direct string from children array', () => {
+      const children = ['Dashboard', <Icon code='dashboard' key='1' />];
+      const text = extractTextContent(children);
+      expect(text).toBe('Dashboard');
+    });
+
+    it('extracts string from nested React element children', () => {
+      const children = [
+        <span key='1'>
+          <Icon code='dashboard' />
+          Dashboard
+        </span>,
+      ];
+      const text = extractTextContent(children);
+      expect(text).toBe('Dashboard');
+    });
+
+    it('returns undefined when no string is found', () => {
+      const children = [<Icon code='dashboard' key='1' />, <span key='2' />];
+      const text = extractTextContent(children);
+      expect(text).toBeUndefined();
+    });
+
+    it('returns undefined for empty array', () => {
+      const text = extractTextContent([]);
+      expect(text).toBeUndefined();
+    });
+  });
+
+  describe('partitionIconAndContent', () => {
+    it('separates first icon from rest of content', () => {
+      const children = [
+        <Icon code='dashboard' key='1' />,
+        <span key='2'>Dashboard</span>,
+        <span key='3'>Text</span>,
+      ];
+
+      const { firstIcon, textContent } = partitionIconAndContent(children);
+
+      expect(firstIcon).toBeTruthy();
+      expect((firstIcon as ReactElement).props.code).toBe('dashboard');
+      expect(textContent).toHaveLength(2);
+    });
+
+    it('returns null for firstIcon when no icon is present', () => {
+      const children = [<span key='1'>Text</span>, <div key='2'>Content</div>];
+
+      const { firstIcon, textContent } = partitionIconAndContent(children);
+
+      expect(firstIcon).toBeNull();
+      expect(textContent).toHaveLength(2);
+    });
+
+    it('handles icon in the middle of children', () => {
+      const children = [
+        <span key='1'>Before</span>,
+        <Icon code='dashboard' key='2' />,
+        <span key='3'>After</span>,
+      ];
+
+      const { firstIcon, textContent } = partitionIconAndContent(children);
+
+      expect(firstIcon).toBeTruthy();
+      expect((firstIcon as ReactElement).props.code).toBe('dashboard');
+      expect(textContent).toHaveLength(2);
+    });
+
+    it('handles empty children', () => {
+      const { firstIcon, textContent } = partitionIconAndContent([]);
+
+      expect(firstIcon).toBeNull();
+      expect(textContent).toEqual([]);
+    });
+  });
+
+  describe('wrapTextContent', () => {
+    it('wraps content in SidebarItemTextContent styled component', () => {
+      const content = [<span key='1'>Text</span>];
+      const wrapped = wrapTextContent(content, false);
+
+      expect(wrapped).toBeTruthy();
+      const { container } = render(<>{wrapped}</>);
+      const textContent = container.querySelector('span');
+      expect(textContent).toBeTruthy();
+      expect(textContent).toHaveTextContent('Text');
+    });
+
+    it('applies hidden styles when isSidebarCollapsed is true', () => {
+      const content = [<span key='1'>Text</span>];
+      const wrapped = wrapTextContent(content, true);
+
+      expect(wrapped).toBeTruthy();
+      const { container } = render(<>{wrapped}</>);
+
+      const textContentWrapper = container.firstChild;
+      expect(textContentWrapper).toHaveStyle({
+        opacity: '0',
+        visibility: 'hidden',
+      });
+    });
+
+    it('returns null for empty content', () => {
+      expect(wrapTextContent([], false)).toBeNull();
+    });
+  });
+
+  describe('wrapWithTooltip', () => {
+    const ProvidedWrapper = withProviders(
+      ({ children }: { children: React.ReactNode }) => <>{children}</>
+    );
+
+    it('wraps content in Tooltip when tooltipText is provided', () => {
+      const content = <span>Content</span>;
+      const wrapped = wrapWithTooltip(content, 'Tooltip text');
+
+      expect(wrapped).toBeTruthy();
+      const { container } = render(
+        <ProvidedWrapper>{wrapped}</ProvidedWrapper>
+      );
+      expect(container).toHaveTextContent('Content');
+      // Tooltip content is rendered but may not be immediately visible
+      // We verify the structure exists by checking the content is wrapped
+      expect(wrapped).not.toBe(content);
+    });
+
+    it('returns content as-is when tooltipText is not provided', () => {
+      const content = <span>Content</span>;
+      const wrapped = wrapWithTooltip(content);
+
+      expect(wrapped).toBe(content);
+    });
+
+    it('returns content as-is when tooltipText is undefined', () => {
+      const content = <span>Content</span>;
+      const wrapped = wrapWithTooltip(content, undefined);
+
+      expect(wrapped).toBe(content);
+    });
+  });
+
+  describe('createWrapperProps', () => {
+    it('creates props object with all parameters', () => {
+      const props = createWrapperProps(true, true, true, 'header');
+
+      expect(props).toEqual({
+        isActive: true,
+        isSidebarCollapsed: true,
+        isNested: true,
+        sectionVariant: 'header',
+      });
+    });
+
+    it('handles undefined values', () => {
+      const props = createWrapperProps(
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+
+      expect(props).toEqual({
+        isActive: undefined,
+        isSidebarCollapsed: undefined,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+  });
+
+  describe('createLinkWrapperProps', () => {
+    it('creates props object with isActive and isSidebarCollapsed', () => {
+      const props = createLinkWrapperProps(true, true);
+
+      expect(props).toEqual({
+        isActive: true,
+        isSidebarCollapsed: true,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+
+    it('handles undefined values', () => {
+      const props = createLinkWrapperProps(undefined, undefined);
+
+      expect(props).toEqual({
+        isActive: undefined,
+        isSidebarCollapsed: undefined,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+  });
+
+  describe('createLinkStyledProps', () => {
+    it('creates props object with href, isActive, and isSidebarCollapsed', () => {
+      const props = createLinkStyledProps('/dashboard', true, false);
+
+      expect(props).toEqual({
+        'aria-current': 'page',
+        href: '/dashboard',
+        isActive: true,
+        isSidebarCollapsed: false,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+
+    it('does not include aria-current when isActive is false', () => {
+      const props = createLinkStyledProps('/dashboard', false, false);
+
+      expect(props).toEqual({
+        href: '/dashboard',
+        isActive: false,
+        isSidebarCollapsed: false,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+
+    it('does not include aria-current when href is undefined', () => {
+      const props = createLinkStyledProps(undefined, true, false);
+
+      expect(props).toEqual({
+        href: undefined,
+        isActive: true,
+        isSidebarCollapsed: false,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+
+    it('handles undefined values', () => {
+      const props = createLinkStyledProps(undefined, undefined, undefined);
+
+      expect(props).toEqual({
+        href: undefined,
+        isActive: undefined,
+        isSidebarCollapsed: undefined,
+        isNested: undefined,
+        sectionVariant: undefined,
+      });
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemRenderers.test.tsx
+++ b/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemRenderers.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { withProviders } from '@dt-dds/react-core';
+import { Icon } from '@dt-dds/react-icon';
+
+import {
+  renderCollapsed,
+  renderContent,
+  renderExpanded,
+} from '../sidebarItemRenderers';
+
+describe('sidebarItemRenderers', () => {
+  describe('renderCollapsed', () => {
+    const ProvidedWrapper = withProviders(
+      ({ children }: { children: React.ReactNode }) => <>{children}</>
+    );
+
+    describe('with custom link element', () => {
+      it('extracts icons from link children and renders wrapped link', () => {
+        const MockLink = ({
+          href,
+          children,
+        }: {
+          href: string;
+          children: React.ReactNode;
+        }) => <a href={href}>{children}</a>;
+
+        const linkElement = (
+          <MockLink href='/dashboard'>
+            <Icon code='dashboard' />
+            <span>Dashboard</span>
+          </MockLink>
+        );
+
+        const result = renderCollapsed(
+          linkElement as React.ReactElement,
+          undefined,
+          false,
+          true
+        );
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        // Should only contain icon, not text
+        expect(link).not.toHaveTextContent('Dashboard');
+      });
+
+      it('returns null when link has no children', () => {
+        const MockLink = ({ href }: { href: string }) => (
+          <a aria-label='Dashboard link' href={href} />
+        );
+
+        const linkElement = <MockLink href='/dashboard' />;
+
+        const result = renderCollapsed(
+          linkElement as React.ReactElement,
+          undefined,
+          false,
+          true
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null when link has no icons', () => {
+        const MockLink = ({
+          href,
+          children,
+        }: {
+          href: string;
+          children: React.ReactNode;
+        }) => <a href={href}>{children}</a>;
+
+        const linkElement = (
+          <MockLink href='/dashboard'>
+            <span>Dashboard</span>
+          </MockLink>
+        );
+
+        const result = renderCollapsed(
+          linkElement as React.ReactElement,
+          undefined,
+          false,
+          true
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('with href prop', () => {
+      it('filters icons and renders styled link', () => {
+        const children = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderCollapsed(children, '/dashboard', false, true);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        // Should only contain icon
+        expect(link).not.toHaveTextContent('Dashboard');
+      });
+
+      it('returns null when no icons are present', () => {
+        const children = [<span key='1'>Dashboard</span>];
+
+        const result = renderCollapsed(children, '/dashboard', false, true);
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('renderExpanded', () => {
+    const ProvidedWrapper = withProviders(
+      ({ children }: { children: React.ReactNode }) => <>{children}</>
+    );
+
+    describe('with custom link element', () => {
+      it('partitions link children and renders with wrapper', () => {
+        const MockLink = ({
+          href,
+          children,
+        }: {
+          href: string;
+          children: React.ReactNode;
+        }) => <a href={href}>{children}</a>;
+
+        const content = (
+          <>
+            <MockLink href='/dashboard'>
+              <Icon code='dashboard' />
+              <span>Dashboard</span>
+            </MockLink>
+            <span key='1'>Extra</span>
+          </>
+        );
+
+        const result = renderExpanded(content, undefined, false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        // Should contain both icon and text
+        expect(link).toHaveTextContent('Dashboard');
+      });
+    });
+
+    describe('with href prop', () => {
+      it('renders content with href wrapped in styled link', () => {
+        const content = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderExpanded(content, '/dashboard', false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        expect(link).toHaveTextContent('Dashboard');
+      });
+
+      it('renders content without href when href is not provided', () => {
+        const content = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderExpanded(content, undefined, false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        // Should not have a link
+        const link = container.querySelector('a');
+        expect(link).toBeNull();
+        // But should have content
+        expect(container).toHaveTextContent('Dashboard');
+      });
+    });
+  });
+
+  describe('renderContent', () => {
+    const ProvidedWrapper = withProviders(
+      ({ children }: { children: React.ReactNode }) => <>{children}</>
+    );
+
+    describe('collapsed state', () => {
+      it('renders collapsed with link child', () => {
+        const MockLink = ({
+          href,
+          children,
+        }: {
+          href: string;
+          children: React.ReactNode;
+        }) => <a href={href}>{children}</a>;
+
+        const content = (
+          <MockLink href='/dashboard'>
+            <Icon code='dashboard' />
+            <span>Dashboard</span>
+          </MockLink>
+        );
+
+        const result = renderContent(content, undefined, false, true);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        // Should only show icon
+        expect(link).not.toHaveTextContent('Dashboard');
+      });
+
+      it('renders collapsed with href prop', () => {
+        const content = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderContent(content, '/dashboard', false, true);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+      });
+
+      it('returns null when collapsed and no icons present', () => {
+        const content = <span>No Icon</span>;
+
+        const result = renderContent(content, '/dashboard', false, true);
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('expanded state', () => {
+      it('renders expanded with link child', () => {
+        const MockLink = ({
+          href,
+          children,
+        }: {
+          href: string;
+          children: React.ReactNode;
+        }) => <a href={href}>{children}</a>;
+
+        const content = (
+          <>
+            <MockLink href='/dashboard'>
+              <Icon code='dashboard' />
+              <span>Dashboard</span>
+            </MockLink>
+            <span>Extra</span>
+          </>
+        );
+
+        const result = renderContent(content, undefined, false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        // Should show both icon and text
+        expect(link).toHaveTextContent('Dashboard');
+      });
+
+      it('renders expanded with href prop', () => {
+        const content = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderContent(content, '/dashboard', false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        const link = container.querySelector('a[href="/dashboard"]');
+        expect(link).toBeTruthy();
+        expect(link).toHaveTextContent('Dashboard');
+      });
+
+      it('renders expanded without link when no href or link child', () => {
+        const content = [
+          <Icon code='dashboard' key='1' />,
+          <span key='2'>Dashboard</span>,
+        ];
+
+        const result = renderContent(content, undefined, false, false);
+
+        expect(result).toBeTruthy();
+        const { container } = render(
+          <ProvidedWrapper>{result}</ProvidedWrapper>
+        );
+        // Should not have a link
+        const link = container.querySelector('a');
+        expect(link).toBeNull();
+        // But should have content
+        expect(container).toHaveTextContent('Dashboard');
+      });
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemUtils.test.tsx
+++ b/packages/react-packages/sidebar/src/utils/__tests__/sidebarItemUtils.test.tsx
@@ -1,0 +1,330 @@
+import { Fragment, ReactElement } from 'react';
+
+import { Icon } from '@dt-dds/react-icon';
+
+import { SidebarItem } from '../../components/SidebarItem/SidebarItem';
+import { SidebarSubList } from '../../components/SidebarSubList/SidebarSubList';
+import {
+  containsActiveSidebarItem,
+  findSubListInChildren,
+  flattenChildren,
+  isLinkElement,
+  isLinkTarget,
+  partitionChildren,
+} from '../sidebarItemUtils';
+import { isSidebarSubList } from '../sidebarUtils';
+import { isCurrentUrl } from '../urlUtils';
+
+describe('sidebarItemUtils', () => {
+  describe('isSidebarSubList', () => {
+    it('returns true for SidebarSubList component', () => {
+      expect(
+        isSidebarSubList(
+          <SidebarSubList>
+            <SidebarItem>Item</SidebarItem>
+          </SidebarSubList>
+        )
+      ).toBe(true);
+    });
+
+    it('returns false for non-SidebarSubList elements', () => {
+      expect(isSidebarSubList(<div>content</div>)).toBe(false);
+      expect(isSidebarSubList('text')).toBe(false);
+      expect(isSidebarSubList(null)).toBe(false);
+    });
+
+    it('returns true for components with displayName "SidebarSubList"', () => {
+      const MockSubList = ({ children }: { children: React.ReactNode }) => (
+        <ul>{children}</ul>
+      );
+      MockSubList.displayName = 'SidebarSubList';
+
+      expect(
+        isSidebarSubList(
+          <MockSubList>
+            <li>Item</li>
+          </MockSubList>
+        )
+      ).toBe(true);
+    });
+
+    it('returns true for functions named "SidebarSubList"', () => {
+      const SidebarSubList = ({ children }: { children: React.ReactNode }) => {
+        return <ul>{children}</ul>;
+      };
+
+      expect(
+        isSidebarSubList(
+          <SidebarSubList>
+            <li>Item</li>
+          </SidebarSubList>
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('isLinkElement', () => {
+    it('returns true for native <a> element', () => {
+      expect(isLinkElement(<a href='/dashboard'>Link</a>)).toBe(true);
+    });
+
+    it('returns true for components with href prop', () => {
+      const MockLink = ({
+        href,
+        children,
+      }: {
+        href: string;
+        children: React.ReactNode;
+      }) => <a href={href}>{children}</a>;
+
+      expect(isLinkElement(<MockLink href='/dashboard'>Link</MockLink>)).toBe(
+        true
+      );
+    });
+
+    it('returns false for elements without href', () => {
+      expect(isLinkElement(<div>content</div>)).toBe(false);
+      expect(isLinkElement(<span>text</span>)).toBe(false);
+      expect(isLinkElement('text')).toBe(false);
+      expect(isLinkElement(null)).toBe(false);
+    });
+  });
+
+  describe('findSubListInChildren', () => {
+    it('returns true when node itself is a SubList', () => {
+      const node = (
+        <SidebarSubList>
+          <SidebarItem>Item</SidebarItem>
+        </SidebarSubList>
+      );
+
+      expect(findSubListInChildren(node)).toBe(true);
+    });
+
+    it('returns true when SubList is in Fragment', () => {
+      const node = (
+        <SidebarSubList>
+          <SidebarItem>Item</SidebarItem>
+        </SidebarSubList>
+      );
+
+      expect(findSubListInChildren(node)).toBe(true);
+    });
+
+    it('returns false when no SubList is present', () => {
+      const node = (
+        <div>
+          <span>content</span>
+        </div>
+      );
+
+      expect(findSubListInChildren(node)).toBe(false);
+    });
+
+    it('returns false for non-element nodes', () => {
+      expect(findSubListInChildren('text')).toBe(false);
+      expect(findSubListInChildren(null)).toBe(false);
+    });
+  });
+
+  describe('flattenChildren', () => {
+    it('flattens simple children array', () => {
+      const children = [<span key='1'>1</span>, <span key='2'>2</span>];
+      const flattened = flattenChildren(children);
+
+      expect(flattened).toHaveLength(2);
+      expect((flattened[0] as ReactElement).props.children).toBe('1');
+      expect((flattened[1] as ReactElement).props.children).toBe('2');
+    });
+
+    it('flattens nested Fragments', () => {
+      const children = (
+        <>
+          <span>1</span>
+          <>
+            <span>2</span>
+            <span>3</span>
+          </>
+        </>
+      );
+
+      const flattened = flattenChildren(children);
+      expect(flattened).toHaveLength(3);
+    });
+
+    it('handles mixed content with Fragments', () => {
+      const children = (
+        <>
+          <span>1</span>
+          <span>2</span>
+          <span>3</span>
+        </>
+      );
+
+      const flattened = flattenChildren(children);
+      expect(flattened).toHaveLength(3);
+    });
+
+    it('handles empty children', () => {
+      expect(flattenChildren(null)).toEqual([]);
+      expect(flattenChildren([])).toEqual([]);
+    });
+  });
+
+  describe('partitionChildren', () => {
+    it('partitions children into SubList and other children', () => {
+      const children = (
+        <>
+          <span>Content</span>
+          <SidebarSubList>
+            <SidebarItem>Item</SidebarItem>
+          </SidebarSubList>
+          <Icon code='dashboard' />
+        </>
+      );
+
+      const { subList, otherChildren } = partitionChildren(children);
+
+      expect(subList).toHaveLength(1);
+      expect(otherChildren).toHaveLength(2);
+    });
+
+    it('handles multiple SubLists', () => {
+      const children = (
+        <>
+          <SidebarSubList>
+            <SidebarItem>Item 1</SidebarItem>
+          </SidebarSubList>
+          <span>Content</span>
+          <SidebarSubList>
+            <SidebarItem>Item 2</SidebarItem>
+          </SidebarSubList>
+        </>
+      );
+
+      const { subList, otherChildren } = partitionChildren(children);
+
+      expect(subList).toHaveLength(2);
+      expect(otherChildren).toHaveLength(1);
+    });
+
+    it('handles children with nested Fragments', () => {
+      const children = (
+        <>
+          <span>Content</span>
+          <SidebarSubList>
+            <SidebarItem>Item</SidebarItem>
+          </SidebarSubList>
+        </>
+      );
+
+      const { subList, otherChildren } = partitionChildren(children);
+
+      expect(subList).toHaveLength(1);
+      expect(otherChildren).toHaveLength(1);
+    });
+
+    it('returns empty arrays when no children', () => {
+      const { subList, otherChildren } = partitionChildren(null);
+
+      expect(subList).toEqual([]);
+      expect(otherChildren).toEqual([]);
+    });
+  });
+
+  describe('containsActiveSidebarItem', () => {
+    let locationMock: Location;
+
+    beforeEach(() => {
+      // Create a mock location object
+      locationMock = {
+        pathname: '/dashboard',
+        href: 'http://localhost/dashboard',
+        origin: 'http://localhost',
+      } as Location;
+
+      // Mock window.location
+      Object.defineProperty(window, 'location', {
+        value: locationMock,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('returns true when SidebarItem href matches current path', () => {
+      const node = <SidebarItem href='/dashboard'>Dashboard</SidebarItem>;
+
+      expect(containsActiveSidebarItem(node, '/dashboard', isCurrentUrl)).toBe(
+        true
+      );
+    });
+
+    it('returns false when SidebarItem href does not match', () => {
+      const node = <SidebarItem href='/settings'>Settings</SidebarItem>;
+
+      expect(containsActiveSidebarItem(node, '/dashboard', isCurrentUrl)).toBe(
+        false
+      );
+    });
+
+    it('recursively checks nested SidebarItems', () => {
+      const node = (
+        <div>
+          <SidebarItem href='/other'>Other</SidebarItem>
+          <SidebarSubList>
+            <SidebarItem href='/dashboard'>Dashboard</SidebarItem>
+          </SidebarSubList>
+        </div>
+      );
+
+      expect(containsActiveSidebarItem(node, '/dashboard', isCurrentUrl)).toBe(
+        true
+      );
+    });
+
+    it('returns false for non-element nodes', () => {
+      expect(
+        containsActiveSidebarItem('text', '/dashboard', isCurrentUrl)
+      ).toBe(false);
+      expect(containsActiveSidebarItem(null, '/dashboard', isCurrentUrl)).toBe(
+        false
+      );
+    });
+
+    it('returns false when no children are present', () => {
+      const node = <div />;
+
+      expect(containsActiveSidebarItem(node, '/dashboard', isCurrentUrl)).toBe(
+        false
+      );
+    });
+  });
+
+  describe('isLinkTarget', () => {
+    it('returns true when target is a link element', () => {
+      const link = document.createElement('a');
+      link.href = '/dashboard';
+
+      expect(isLinkTarget(link)).toBe(true);
+    });
+
+    it('returns true when target is inside a link element', () => {
+      const link = document.createElement('a');
+      link.href = '/dashboard';
+      const span = document.createElement('span');
+      link.appendChild(span);
+
+      expect(isLinkTarget(span)).toBe(true);
+    });
+
+    it('returns false when target is not a link', () => {
+      const div = document.createElement('div');
+
+      expect(isLinkTarget(div)).toBe(false);
+    });
+
+    it('returns false when target is null', () => {
+      expect(isLinkTarget(null)).toBe(false);
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/utils/__tests__/sidebarUtils.test.tsx
+++ b/packages/react-packages/sidebar/src/utils/__tests__/sidebarUtils.test.tsx
@@ -1,0 +1,326 @@
+import { ReactElement } from 'react';
+
+import { Icon } from '@dt-dds/react-icon';
+import { IconButton } from '@dt-dds/react-icon-button';
+
+import { SidebarItem, SidebarSubList, SidebarToggle } from '../../components';
+import {
+  SIDEBAR_DEFAULT_OFFSET_POSITION,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_MINI,
+} from '../../constants';
+import {
+  calculateSidebarPosition,
+  calculateSidebarWidth,
+  extractIconsFromChildren,
+  hasFirstItemIcon,
+  isIconElement,
+  isSidebarItemElement,
+} from '../sidebarUtils';
+
+describe('sidebarUtils', () => {
+  describe('isIconElement', () => {
+    it('returns true for Icon, IconButton, SidebarToggle components', () => {
+      expect(isIconElement(<Icon code='dashboard' />)).toBe(true);
+      expect(isIconElement(<IconButton />)).toBe(true);
+      expect(isIconElement(<SidebarToggle onClick={jest.fn()} />)).toBe(true);
+    });
+
+    it('returns true for native <i> element', () => {
+      expect(isIconElement(<i>icon</i>)).toBe(true);
+    });
+
+    it('returns false for non-icon elements and non-element nodes', () => {
+      expect(isIconElement(<div>content</div>)).toBe(false);
+      expect(isIconElement('text')).toBe(false);
+      expect(isIconElement(null)).toBe(false);
+    });
+
+    it('returns true for components with displayName Icon/IconButton/SidebarToggle', () => {
+      const MockIcon = () => <span>icon</span>;
+      MockIcon.displayName = 'Icon';
+      expect(isIconElement(<MockIcon />)).toBe(true);
+
+      const MockIconButton = () => <span>icon</span>;
+      MockIconButton.displayName = 'IconButton';
+      expect(isIconElement(<MockIconButton />)).toBe(true);
+
+      const MockToggle = () => <span>toggle</span>;
+      MockToggle.displayName = 'SidebarToggle';
+      expect(isIconElement(<MockToggle />)).toBe(true);
+    });
+
+    it('returns true for functions named Icon/IconButton/SidebarToggle', () => {
+      const Icon = () => {
+        return <span>icon</span>;
+      };
+      expect(isIconElement(<Icon />)).toBe(true);
+
+      const IconButton = () => {
+        return <span>icon</span>;
+      };
+      expect(isIconElement(<IconButton />)).toBe(true);
+
+      const SidebarToggle = () => {
+        return <span>toggle</span>;
+      };
+      expect(isIconElement(<SidebarToggle />)).toBe(true);
+    });
+  });
+
+  describe('isSidebarItemElement', () => {
+    it('returns true for SidebarItem component', () => {
+      expect(isSidebarItemElement(<SidebarItem>Item</SidebarItem>)).toBe(true);
+    });
+
+    it('returns false for non-SidebarItem elements and non-element nodes', () => {
+      expect(isSidebarItemElement(<div>content</div>)).toBe(false);
+      expect(isSidebarItemElement('text')).toBe(false);
+      expect(isSidebarItemElement(null)).toBe(false);
+    });
+
+    it('returns true for components with displayName "SidebarItem"', () => {
+      const MockItem = ({ children }: { children: React.ReactNode }) => (
+        <li>{children}</li>
+      );
+      MockItem.displayName = 'SidebarItem';
+      expect(isSidebarItemElement(<MockItem>Item</MockItem>)).toBe(true);
+    });
+
+    it('returns true for function named "SidebarItem"', () => {
+      const SidebarItem = ({ children }: { children: React.ReactNode }) => {
+        return <li>{children}</li>;
+      };
+      expect(isSidebarItemElement(<SidebarItem>Item</SidebarItem>)).toBe(true);
+    });
+  });
+
+  describe('extractIconsFromChildren', () => {
+    it('extracts icons from direct children', () => {
+      const children = [
+        <Icon code='dashboard' key='1' />,
+        <span key='2'>Text</span>,
+        <Icon code='settings' key='3' />,
+      ];
+
+      const icons = extractIconsFromChildren(children);
+
+      expect(icons).toHaveLength(2);
+      expect((icons[0] as ReactElement).props.code).toBe('dashboard');
+      expect((icons[1] as ReactElement).props.code).toBe('settings');
+    });
+
+    it('extracts icons from nested structures and Fragments', () => {
+      const MockLink = ({
+        href,
+        children,
+      }: {
+        href: string;
+        children: React.ReactNode;
+      }) => <a href={href}>{children}</a>;
+
+      const children = (
+        <>
+          <MockLink href='/dashboard'>
+            <Icon code='dashboard' />
+            <span>Dashboard</span>
+          </MockLink>
+          <Icon code='settings' />
+        </>
+      );
+
+      const icons = extractIconsFromChildren(children);
+      expect(icons).toHaveLength(2);
+    });
+
+    it('stops at SidebarSubList and SidebarItem - does not extract from nested', () => {
+      const children = [
+        <Icon code='dashboard' key='1' />,
+        <SidebarSubList key='2'>
+          <SidebarItem>
+            <Icon code='settings' />
+          </SidebarItem>
+        </SidebarSubList>,
+        <SidebarItem key='3'>
+          <Icon code='home' />
+        </SidebarItem>,
+      ];
+
+      const icons = extractIconsFromChildren(children);
+      expect(icons).toHaveLength(1);
+      expect((icons[0] as ReactElement).props.code).toBe('dashboard');
+    });
+
+    it('returns empty array when no icons or empty children', () => {
+      expect(extractIconsFromChildren([<span key='1'>Text</span>])).toEqual([]);
+      expect(extractIconsFromChildren([])).toEqual([]);
+      expect(extractIconsFromChildren(null)).toEqual([]);
+    });
+
+    it('stops at SubList by displayName and function name', () => {
+      const MockSubList1 = ({ children }: { children: React.ReactNode }) => (
+        <ul>{children}</ul>
+      );
+      MockSubList1.displayName = 'SidebarSubList';
+
+      const SidebarSubList = ({ children }: { children: React.ReactNode }) => {
+        return <ul>{children}</ul>;
+      };
+
+      expect(
+        extractIconsFromChildren([
+          <Icon code='dashboard' key='1' />,
+          <MockSubList1 key='2'>
+            <Icon code='settings' />
+          </MockSubList1>,
+        ])
+      ).toHaveLength(1);
+
+      expect(
+        extractIconsFromChildren([
+          <Icon code='dashboard' key='1' />,
+          <SidebarSubList key='2'>
+            <Icon code='settings' />
+          </SidebarSubList>,
+        ])
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('hasFirstItemIcon', () => {
+    it('returns true when SidebarItem has icon (direct or in Link)', () => {
+      const MockLink = ({
+        href,
+        children,
+      }: {
+        href: string;
+        children: React.ReactNode;
+      }) => <a href={href}>{children}</a>;
+
+      expect(
+        hasFirstItemIcon(
+          <SidebarItem>
+            <Icon code='dashboard' />
+            Dashboard
+          </SidebarItem>
+        )
+      ).toBe(true);
+
+      // Icon in Link
+      expect(
+        hasFirstItemIcon(
+          <SidebarItem>
+            <MockLink href='/dashboard'>
+              <Icon code='dashboard' />
+              Dashboard
+            </MockLink>
+          </SidebarItem>
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when SidebarItem has no icon', () => {
+      expect(hasFirstItemIcon(<SidebarItem>Dashboard</SidebarItem>)).toBe(
+        false
+      );
+    });
+
+    it('returns true when any direct SidebarItem sibling has icon', () => {
+      const children = [
+        <SidebarItem key='1'>No Icon</SidebarItem>,
+        <SidebarItem key='2'>
+          <Icon code='dashboard' />
+          Has Icon
+        </SidebarItem>,
+      ];
+      expect(hasFirstItemIcon(children)).toBe(true);
+    });
+
+    it('returns false when icon is only in nested SubList', () => {
+      const children = (
+        <SidebarItem>
+          Text Only
+          <SidebarSubList>
+            <SidebarItem>
+              <Icon code='dashboard' />
+            </SidebarItem>
+          </SidebarSubList>
+        </SidebarItem>
+      );
+      expect(hasFirstItemIcon(children)).toBe(false);
+    });
+
+    it('returns false for empty or non-SidebarItem children', () => {
+      expect(hasFirstItemIcon(null)).toBe(false);
+      expect(hasFirstItemIcon([])).toBe(false);
+      expect(hasFirstItemIcon([<div key='1'>Not an item</div>])).toBe(false);
+    });
+
+    it('finds SidebarItems nested in wrapper elements', () => {
+      const children = (
+        <nav>
+          <SidebarItem>
+            <Icon code='dashboard' />
+            Dashboard
+          </SidebarItem>
+        </nav>
+      );
+      expect(hasFirstItemIcon(children)).toBe(true);
+    });
+
+    it('finds SidebarItems in Fragment children', () => {
+      const children = (
+        <>
+          <SidebarItem>
+            <Icon code='dashboard' />
+            Dashboard
+          </SidebarItem>
+          <SidebarItem>Settings</SidebarItem>
+        </>
+      );
+      expect(hasFirstItemIcon(children)).toBe(true);
+    });
+  });
+
+  describe('calculateSidebarPosition', () => {
+    it('returns default offset position when mobile and expanded', () => {
+      expect(calculateSidebarPosition(true, true)).toBe(
+        SIDEBAR_DEFAULT_OFFSET_POSITION
+      );
+    });
+
+    it('returns negative sidebar width when mobile and collapsed', () => {
+      expect(calculateSidebarPosition(true, false)).toBe(-SIDEBAR_WIDTH);
+    });
+
+    it('returns default offset position when desktop and expanded', () => {
+      expect(calculateSidebarPosition(false, true)).toBe(
+        SIDEBAR_DEFAULT_OFFSET_POSITION
+      );
+    });
+
+    it('returns default offset position when desktop and collapsed', () => {
+      expect(calculateSidebarPosition(false, false)).toBe(
+        SIDEBAR_DEFAULT_OFFSET_POSITION
+      );
+    });
+  });
+
+  describe('calculateSidebarWidth', () => {
+    it('returns full width when mobile and expanded', () => {
+      expect(calculateSidebarWidth(true, true)).toBe(SIDEBAR_WIDTH);
+    });
+
+    it('returns full width when mobile and collapsed', () => {
+      expect(calculateSidebarWidth(true, false)).toBe(SIDEBAR_WIDTH);
+    });
+
+    it('returns full width when desktop and expanded', () => {
+      expect(calculateSidebarWidth(false, true)).toBe(SIDEBAR_WIDTH);
+    });
+
+    it('returns mini width when desktop and collapsed', () => {
+      expect(calculateSidebarWidth(false, false)).toBe(SIDEBAR_WIDTH_MINI);
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/utils/__tests__/urlUtils.test.ts
+++ b/packages/react-packages/sidebar/src/utils/__tests__/urlUtils.test.ts
@@ -1,0 +1,157 @@
+import { getCurrentPath, getHrefPath, isCurrentUrl } from '../urlUtils';
+
+const mockLocation = ({
+  pathname,
+  href,
+  origin,
+}: {
+  pathname: string;
+  href: string;
+  origin: string;
+}) => ({ pathname, href, origin } as Location);
+
+describe('urlUtils', () => {
+  describe('getCurrentPath', () => {
+    it('returns current pathname from window.location', () => {
+      const locationMock = mockLocation({
+        pathname: '/dashboard',
+        href: 'http://localhost/dashboard',
+        origin: 'http://localhost',
+      });
+
+      // Mock window.location
+      Object.defineProperty(window, 'location', {
+        value: locationMock,
+        writable: true,
+        configurable: true,
+      });
+
+      expect(getCurrentPath()).toBe('/dashboard');
+    });
+
+    it('returns empty string in SSR environment', () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error - simulate SSR
+      delete globalThis.window;
+
+      expect(getCurrentPath()).toBe('');
+
+      // Restore
+      globalThis.window = originalWindow;
+    });
+  });
+
+  describe('getHrefPath', () => {
+    it('extracts pathname from absolute URL', () => {
+      expect(getHrefPath('https://example.com/dashboard')).toBe('/dashboard');
+      expect(getHrefPath('http://localhost:3000/settings')).toBe('/settings');
+    });
+
+    it('extracts pathname from relative URL', () => {
+      // Create a mock location object
+      const locationMock = mockLocation({
+        pathname: '/',
+        href: 'https://example.com/',
+        origin: 'https://example.com',
+      });
+
+      // Mock window.location
+      Object.defineProperty(window, 'location', {
+        value: locationMock,
+        writable: true,
+        configurable: true,
+      });
+
+      expect(getHrefPath('/dashboard')).toBe('/dashboard');
+      expect(getHrefPath('/settings?tab=general')).toBe('/settings');
+    });
+
+    it('handles invalid URLs by falling back to normalized path', () => {
+      const originalURL = window.URL;
+      class ThrowingURL {
+        constructor() {
+          throw new TypeError('invalid url');
+        }
+      }
+
+      // @ts-expect-error - override for test
+      window.URL = ThrowingURL;
+
+      try {
+        expect(getHrefPath('invalid')).toBe('/invalid');
+        expect(getHrefPath('/already-valid')).toBe('/already-valid');
+      } finally {
+        window.URL = originalURL;
+      }
+    });
+
+    it('handles relative paths without leading slash', () => {
+      const originalURL = window.URL;
+      class ThrowingURL {
+        constructor() {
+          throw new TypeError('invalid url');
+        }
+      }
+
+      // @ts-expect-error - override for test
+      window.URL = ThrowingURL;
+
+      try {
+        expect(getHrefPath('dashboard')).toBe('/dashboard');
+      } finally {
+        window.URL = originalURL;
+      }
+    });
+
+    it('handles empty string by returning normalized path', () => {
+      // Empty string gets normalized to '/' in the fallback
+      const result = getHrefPath('');
+      expect(result).toBe('/');
+    });
+  });
+
+  describe('isCurrentUrl', () => {
+    let locationMock: Location;
+
+    beforeEach(() => {
+      // Create a mock location object
+      locationMock = mockLocation({
+        pathname: '/dashboard',
+        href: 'http://localhost/dashboard',
+        origin: 'http://localhost',
+      });
+
+      // Mock window.location
+      Object.defineProperty(window, 'location', {
+        value: locationMock,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('returns true when href matches current path', () => {
+      expect(isCurrentUrl('/dashboard')).toBe(true);
+      expect(isCurrentUrl('https://example.com/dashboard')).toBe(true);
+    });
+
+    it('returns false when href does not match current path', () => {
+      expect(isCurrentUrl('/settings')).toBe(false);
+      expect(isCurrentUrl('/dashboard/settings')).toBe(false);
+    });
+
+    it('returns false when href is undefined', () => {
+      expect(isCurrentUrl(undefined)).toBe(false);
+    });
+
+    it('uses provided currentPath when given', () => {
+      expect(isCurrentUrl('/settings', '/settings')).toBe(true);
+      expect(isCurrentUrl('/dashboard', '/settings')).toBe(false);
+    });
+
+    it('handles query strings and hash in href', () => {
+      // getHrefPath extracts only pathname, so query/hash are ignored
+      expect(isCurrentUrl('/dashboard?tab=general')).toBe(true);
+      expect(isCurrentUrl('/dashboard#section')).toBe(true);
+    });
+  });
+});

--- a/packages/react-packages/sidebar/src/utils/index.ts
+++ b/packages/react-packages/sidebar/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './sidebarUtils';
+export * from './urlUtils';
+export * from './sidebarItemUtils';
+export * from './sidebarItemRenderers';

--- a/packages/react-packages/sidebar/src/utils/sidebarItemContent.tsx
+++ b/packages/react-packages/sidebar/src/utils/sidebarItemContent.tsx
@@ -1,0 +1,123 @@
+import { Children, isValidElement, ReactNode } from 'react';
+
+import { Tooltip } from '@dt-dds/react-tooltip';
+
+import { isIconElement, isSidebarToggleElement } from './sidebarUtils';
+import { SidebarItemTextContent } from '../components/SidebarItem/SidebarItem.styled';
+
+import type { SectionVariant } from '../types';
+
+// Extracts the first string content from children array
+export const extractTextContent = (
+  children: ReactNode[]
+): string | undefined => {
+  const directString = children.find(
+    (child): child is string => typeof child === 'string'
+  );
+  if (directString) {
+    return directString;
+  }
+
+  for (const child of children) {
+    if (isSidebarToggleElement(child)) return 'Expand sidebar';
+
+    if (isValidElement(child) && child.props.children) {
+      const nestedChildren = Children.toArray(child.props.children);
+      const nestedString = nestedChildren.find(
+        (nested): nested is string => typeof nested === 'string'
+      );
+      if (nestedString) {
+        return nestedString;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+// Separates the first icon from the rest of the content
+export const partitionIconAndContent = (
+  children: ReactNode
+): { firstIcon: ReactNode | null; textContent: ReactNode[] } => {
+  const childrenArray = Children.toArray(children);
+  const firstIconIndex = childrenArray.findIndex(isIconElement);
+
+  if (firstIconIndex === -1) {
+    return { firstIcon: null, textContent: childrenArray };
+  }
+
+  const firstIcon = childrenArray[firstIconIndex];
+  const textContent = [
+    ...childrenArray.slice(0, firstIconIndex),
+    ...childrenArray.slice(firstIconIndex + 1),
+  ];
+
+  return { firstIcon, textContent };
+};
+
+// Wraps text content in styled component for animation
+export const wrapTextContent = (
+  textContent: ReactNode[],
+  isSidebarCollapsed?: boolean
+): ReactNode | null =>
+  textContent.length > 0 ? (
+    <SidebarItemTextContent isSidebarCollapsed={isSidebarCollapsed}>
+      {textContent}
+    </SidebarItemTextContent>
+  ) : null;
+
+// Conditionally wraps content in a Tooltip with text appearing on the right
+export const wrapWithTooltip = (
+  content: ReactNode,
+  tooltipText?: string
+): ReactNode =>
+  tooltipText ? (
+    <Tooltip>
+      {content}
+      <Tooltip.Content background='full' direction='right'>
+        {tooltipText}
+      </Tooltip.Content>
+    </Tooltip>
+  ) : (
+    content
+  );
+
+// Factory helpers for wrapper components
+export const createWrapperProps = (
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+) => ({
+  isActive,
+  isSidebarCollapsed,
+  isNested,
+  sectionVariant,
+});
+
+export const createLinkWrapperProps = (
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+) => ({
+  isActive,
+  isSidebarCollapsed,
+  isNested,
+  sectionVariant,
+});
+
+export const createLinkStyledProps = (
+  href?: string,
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+) => ({
+  href,
+  isActive,
+  isSidebarCollapsed,
+  isNested,
+  sectionVariant,
+  ...(href && isActive && { 'aria-current': 'page' as const }),
+});

--- a/packages/react-packages/sidebar/src/utils/sidebarItemRenderers.tsx
+++ b/packages/react-packages/sidebar/src/utils/sidebarItemRenderers.tsx
@@ -1,0 +1,245 @@
+import { Children, cloneElement, isValidElement, ReactNode } from 'react';
+
+import {
+  createLinkStyledProps,
+  createLinkWrapperProps,
+  extractTextContent,
+  partitionIconAndContent,
+  wrapTextContent,
+  wrapWithTooltip,
+} from './sidebarItemContent';
+import { isLinkElement } from './sidebarItemUtils';
+import { extractIconsFromChildren, isIconElement } from './sidebarUtils';
+import { SidebarItemLinkStyled } from '../components/SidebarItem/SidebarItem.styled';
+
+import type { SectionVariant } from '../types';
+
+// Renders collapsed content
+export const renderCollapsed = (
+  content: ReactNode,
+  href?: string,
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+): ReactNode | null => {
+  const childrenArray = Children.toArray(content);
+  const hasLinkChild = childrenArray.some(isLinkElement);
+
+  if (hasLinkChild) {
+    const linkElement = childrenArray.find(isLinkElement);
+    if (!linkElement || !isValidElement(linkElement)) {
+      return null;
+    }
+
+    const linkChildren = linkElement.props.children;
+    if (linkChildren === undefined || linkChildren === null) {
+      return null;
+    }
+
+    const iconOnlyContent = extractIconsFromChildren(linkChildren);
+    if (iconOnlyContent.length === 0) {
+      return null;
+    }
+
+    const clonedLink = cloneElement(
+      linkElement,
+      isActive ? { 'aria-current': 'page' as const } : {},
+      iconOnlyContent
+    );
+    const tooltipText = extractTextContent(Children.toArray(linkChildren));
+
+    const color = isActive ? 'accent.default' : 'content.dark';
+    const fontStyles = isActive && !isNested ? 'bodyLgBold' : 'bodyLgRegular';
+
+    const wrappedLink = (
+      <SidebarItemLinkStyled
+        color={color}
+        element='span'
+        fontStyles={fontStyles}
+        isDynamicLink
+        {...createLinkWrapperProps(
+          isActive,
+          isSidebarCollapsed,
+          isNested,
+          sectionVariant
+        )}
+      >
+        {clonedLink}
+      </SidebarItemLinkStyled>
+    );
+
+    return wrapWithTooltip(wrappedLink, tooltipText);
+  }
+
+  const iconOnlyContent = childrenArray.filter(isIconElement);
+  if (iconOnlyContent.length === 0) {
+    return null;
+  }
+
+  const tooltipText = extractTextContent(childrenArray);
+  const element = href ? 'a' : 'span';
+  const color = isActive ? 'accent.default' : 'content.dark';
+  const fontStyles = isActive && !isNested ? 'bodyLgBold' : 'bodyLgRegular';
+
+  const styledLink = (
+    <SidebarItemLinkStyled
+      color={color}
+      element={element}
+      fontStyles={fontStyles}
+      isDynamicLink={false}
+      {...createLinkStyledProps(
+        href,
+        isActive,
+        isSidebarCollapsed,
+        isNested,
+        sectionVariant
+      )}
+    >
+      {iconOnlyContent}
+    </SidebarItemLinkStyled>
+  );
+
+  return wrapWithTooltip(styledLink, tooltipText);
+};
+
+// Renders expanded content
+export const renderExpanded = (
+  content: ReactNode,
+  href?: string,
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+): ReactNode => {
+  const childrenArray = Children.toArray(content);
+  const hasLinkChild = childrenArray.some(isLinkElement);
+
+  const color = isActive ? 'accent.default' : 'content.dark';
+  const footerFontStyles =
+    sectionVariant === 'footer' ? 'bodyLgBold' : 'bodyLgRegular';
+  const fontStyles = isActive && !isNested ? 'bodyLgBold' : footerFontStyles;
+
+  if (hasLinkChild) {
+    const linkElement = childrenArray.find(isLinkElement);
+    if (!linkElement || !isValidElement(linkElement)) {
+      const { firstIcon, textContent } = partitionIconAndContent(content);
+      const wrappedTextContent = wrapTextContent(
+        textContent,
+        isSidebarCollapsed
+      );
+      const element = href ? 'a' : 'span';
+
+      return (
+        <SidebarItemLinkStyled
+          color={color}
+          element={element}
+          fontStyles={fontStyles}
+          isDynamicLink={false}
+          {...createLinkStyledProps(
+            href,
+            isActive,
+            isSidebarCollapsed,
+            isNested,
+            sectionVariant
+          )}
+        >
+          {firstIcon}
+          {wrappedTextContent}
+        </SidebarItemLinkStyled>
+      );
+    }
+
+    const nonLinkChildren = childrenArray.filter(
+      (child) => !isLinkElement(child)
+    );
+
+    const linkChildren = Children.toArray(linkElement.props.children);
+    const { firstIcon, textContent } = partitionIconAndContent(linkChildren);
+    const wrappedTextContent = wrapTextContent(textContent, isSidebarCollapsed);
+
+    const structuredLinkChildren = (
+      <>
+        {firstIcon}
+        {wrappedTextContent}
+      </>
+    );
+
+    const clonedLink = cloneElement(
+      linkElement,
+      isActive ? { 'aria-current': 'page' as const } : {},
+      structuredLinkChildren
+    );
+
+    return (
+      <SidebarItemLinkStyled
+        color={color}
+        element='span'
+        fontStyles={fontStyles}
+        isDynamicLink
+        {...createLinkWrapperProps(
+          isActive,
+          isSidebarCollapsed,
+          isNested,
+          sectionVariant
+        )}
+      >
+        {clonedLink}
+        {nonLinkChildren}
+      </SidebarItemLinkStyled>
+    );
+  }
+
+  const { firstIcon, textContent } = partitionIconAndContent(content);
+  const wrappedTextContent = wrapTextContent(textContent, isSidebarCollapsed);
+  const element = href ? 'a' : 'span';
+
+  return (
+    <SidebarItemLinkStyled
+      color={color}
+      element={element}
+      fontStyles={fontStyles}
+      isDynamicLink={false}
+      {...createLinkStyledProps(
+        href,
+        isActive,
+        isSidebarCollapsed,
+        isNested,
+        sectionVariant
+      )}
+    >
+      {firstIcon}
+      {wrappedTextContent}
+    </SidebarItemLinkStyled>
+  );
+};
+
+// Renders main content
+export const renderContent = (
+  content: ReactNode,
+  href?: string,
+  isActive?: boolean,
+  isSidebarCollapsed?: boolean,
+  isNested?: boolean,
+  sectionVariant?: SectionVariant
+): ReactNode => {
+  if (isSidebarCollapsed) {
+    return renderCollapsed(
+      content,
+      href,
+      isActive,
+      isSidebarCollapsed,
+      isNested,
+      sectionVariant
+    );
+  }
+
+  return renderExpanded(
+    content,
+    href,
+    isActive,
+    isSidebarCollapsed,
+    isNested,
+    sectionVariant
+  );
+};

--- a/packages/react-packages/sidebar/src/utils/sidebarItemUtils.ts
+++ b/packages/react-packages/sidebar/src/utils/sidebarItemUtils.ts
@@ -1,0 +1,82 @@
+import { Children, Fragment, isValidElement, ReactNode } from 'react';
+
+import { isSidebarItemElement, isSidebarSubList } from './sidebarUtils';
+
+// Checks if a ReactNode is a link element
+export const isLinkElement = (child: ReactNode): boolean => {
+  if (!isValidElement(child)) return false;
+
+  return child.type === 'a' || 'href' in (child.props || {});
+};
+
+// Recursively finds SubList in children
+export const findSubListInChildren = (node: ReactNode): boolean => {
+  if (!isValidElement(node)) return false;
+
+  if (isSidebarSubList(node)) return true;
+
+  if (node.type === Fragment && node.props.children) {
+    return Children.toArray(node.props.children).some(findSubListInChildren);
+  }
+
+  return false;
+};
+
+// Flattens children array
+export const flattenChildren = (children: ReactNode): ReactNode[] => {
+  return Children.toArray(children).flatMap((child) => {
+    if (
+      isValidElement(child) &&
+      child.type === Fragment &&
+      child.props.children
+    ) {
+      return flattenChildren(child.props.children);
+    }
+    return [child];
+  });
+};
+
+// Partitions children into SubList and other children
+export const partitionChildren = (children: ReactNode) => {
+  const allChildren = flattenChildren(children);
+
+  return allChildren.reduce<{
+    subList: ReactNode[];
+    otherChildren: ReactNode[];
+  }>(
+    (acc, child) => {
+      if (findSubListInChildren(child)) {
+        acc.subList.push(child);
+      } else {
+        acc.otherChildren.push(child);
+      }
+      return acc;
+    },
+    { subList: [], otherChildren: [] }
+  );
+};
+
+// Checks if a node contains an active SidebarItem
+export const containsActiveSidebarItem = (
+  node: ReactNode,
+  currentPath: string,
+  isCurrentUrl: (href?: string, currentPath?: string) => boolean
+): boolean => {
+  if (!isValidElement(node)) return false;
+
+  if (isSidebarItemElement(node)) {
+    return isCurrentUrl(node.props.href, currentPath);
+  }
+
+  if (!node.props?.children) return false;
+  return Children.toArray(node.props.children).some((childNode) =>
+    containsActiveSidebarItem(childNode, currentPath, isCurrentUrl)
+  );
+};
+
+// Checks if an event target is a link element
+export const isLinkTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+
+  return !!target.closest('a');
+};

--- a/packages/react-packages/sidebar/src/utils/sidebarUtils.ts
+++ b/packages/react-packages/sidebar/src/utils/sidebarUtils.ts
@@ -1,0 +1,196 @@
+import {
+  ReactNode,
+  Children,
+  isValidElement,
+  ElementType,
+  ReactElement,
+  Fragment,
+} from 'react';
+
+import { type SidebarItemProps } from '../components/';
+import {
+  SIDEBAR_DEFAULT_OFFSET_POSITION,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_MINI,
+} from '../constants';
+
+export const calculateSidebarWidth = (
+  isMobile: boolean,
+  isExpanded: boolean
+): number => {
+  if (isMobile || isExpanded) {
+    return SIDEBAR_WIDTH;
+  }
+  return SIDEBAR_WIDTH_MINI;
+};
+
+export const calculateSidebarPosition = (
+  isMobile: boolean,
+  isExpanded: boolean
+): number => {
+  if (isMobile) {
+    return isExpanded ? SIDEBAR_DEFAULT_OFFSET_POSITION : -SIDEBAR_WIDTH;
+  }
+  return SIDEBAR_DEFAULT_OFFSET_POSITION;
+};
+
+type SidebarItemElement = ReactElement<SidebarItemProps>;
+
+// Checks if a ReactNode is a SidebarItem element
+export const isSidebarItemElement = (
+  child: ReactNode
+): child is SidebarItemElement => {
+  if (!isValidElement(child)) return false;
+  const componentType = child.type as ElementType & { displayName?: string };
+  if (componentType?.displayName === 'SidebarItem') return true;
+  if (typeof child.type === 'function' && child.type.name === 'SidebarItem')
+    return true;
+  return false;
+};
+
+// Checks if a ReactNode is a SidebarSubList element
+export const isSidebarSubList = (child: ReactNode): boolean => {
+  if (!isValidElement(child)) return false;
+
+  const componentType = child.type as ElementType & { displayName?: string };
+  if (componentType?.displayName === 'SidebarSubList') return true;
+
+  if (typeof child.type === 'function' && child.type.name === 'SidebarSubList')
+    return true;
+
+  return false;
+};
+
+// Finds all direct SidebarItem elements in children
+const findDirectSidebarItems = (node: ReactNode): ReactNode[] => {
+  const items: ReactNode[] = [];
+
+  if (!isValidElement(node)) return items;
+
+  if (isSidebarItemElement(node)) {
+    items.push(node);
+    return items;
+  }
+
+  if (node.type === Fragment && node.props?.children) {
+    const fragmentChildren = Children.toArray(node.props.children);
+    fragmentChildren.forEach((child) => {
+      if (isValidElement(child) && isSidebarItemElement(child)) {
+        items.push(child);
+      }
+    });
+    return items;
+  }
+
+  if (node.props?.children) {
+    const children = Children.toArray(node.props.children);
+    children.forEach((child) => {
+      if (isValidElement(child) && isSidebarItemElement(child)) {
+        items.push(child);
+      }
+    });
+  }
+
+  return items;
+};
+
+// Checks if a ReactNode is an Icon element
+export const isIconElement = (child: ReactNode): boolean => {
+  if (!isValidElement(child)) return false;
+
+  const componentType = child.type as ElementType & { displayName?: string };
+  if (
+    componentType?.displayName === 'Icon' ||
+    componentType?.displayName === 'IconButton' ||
+    componentType?.displayName === 'SidebarToggle'
+  )
+    return true;
+  if (
+    typeof child.type === 'function' &&
+    (child.type.name === 'Icon' ||
+      child.type.name === 'IconButton' ||
+      child.type.name === 'SidebarToggle')
+  )
+    return true;
+
+  if (typeof child.type === 'string' && child.type === 'i') return true;
+  return false;
+};
+
+// Checks if a ReactNode is a SidebarToggle element
+export const isSidebarToggleElement = (child: ReactNode): boolean => {
+  if (!isValidElement(child)) return false;
+
+  const componentType = child.type as ElementType & { displayName?: string };
+  if (componentType?.displayName === 'SidebarToggle') return true;
+
+  if (typeof child.type === 'function' && child.type.name === 'SidebarToggle')
+    return true;
+
+  return false;
+};
+
+// Extracts icon elements from a node tree
+const extractIconsFromNode = (
+  node: ReactNode,
+  icons: ReactNode[] = []
+): ReactNode[] => {
+  if (!isValidElement(node)) return icons;
+
+  if (isIconElement(node)) {
+    icons.push(node);
+    return icons;
+  }
+
+  if (isSidebarSubList(node)) return icons;
+
+  if (isSidebarItemElement(node)) return icons;
+
+  if (node.type === Fragment && node.props?.children) {
+    const fragmentChildren = Children.toArray(node.props.children);
+    fragmentChildren.forEach((child) => extractIconsFromNode(child, icons));
+    return icons;
+  }
+
+  const nodeChildren = node.props?.children;
+  if (nodeChildren !== undefined && nodeChildren !== null) {
+    const nestedChildren = Children.toArray(nodeChildren);
+    nestedChildren.forEach((child) => extractIconsFromNode(child, icons));
+  }
+
+  return icons;
+};
+
+// Extracts all icon elements from children recursively
+export const extractIconsFromChildren = (
+  children: ReactNode | ReactNode[]
+): ReactNode[] => {
+  const icons: ReactNode[] = [];
+  const childrenArray = Children.toArray(children);
+  childrenArray.forEach((child) => {
+    extractIconsFromNode(child, icons);
+  });
+  return icons;
+};
+
+// Checks if any icon exists in children
+const hasIconInChildren = (children: ReactNode | ReactNode[]): boolean => {
+  return extractIconsFromChildren(children).length > 0;
+};
+
+// Checks if any direct SidebarItem child has an icon element
+export const hasFirstItemIcon = (children: ReactNode): boolean => {
+  const childrenArray = Children.toArray(children);
+
+  return childrenArray.some((child) => {
+    const directItems = findDirectSidebarItems(child);
+
+    return directItems.some((item) => {
+      if (isValidElement(item)) {
+        const itemChildren = item.props.children || [];
+        return hasIconInChildren(itemChildren);
+      }
+      return false;
+    });
+  });
+};

--- a/packages/react-packages/sidebar/src/utils/urlUtils.ts
+++ b/packages/react-packages/sidebar/src/utils/urlUtils.ts
@@ -1,0 +1,27 @@
+// Gets the current pathname from window.location
+export const getCurrentPath = (): string => {
+  if (typeof window === 'undefined') return '';
+  return window.location.pathname;
+};
+
+// Extracts the pathname from an href string
+export const getHrefPath = (href: string): string | null => {
+  try {
+    return new URL(
+      href,
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : 'http://localhost'
+    ).pathname;
+  } catch {
+    return href.startsWith('/') ? href : `/${href}`;
+  }
+};
+
+// Checks if an href matches the current URL pathname
+export const isCurrentUrl = (href?: string, currentPath?: string): boolean => {
+  if (!href) return false;
+  const pathToCompare = currentPath ?? getCurrentPath();
+  const hrefPath = getHrefPath(href);
+  return hrefPath ? pathToCompare === hrefPath : false;
+};

--- a/packages/react-packages/sidebar/tsconfig.json
+++ b/packages/react-packages/sidebar/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "exclude": ["dist", "build", "node_modules"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "index.ts"],
+}

--- a/packages/react-packages/sidebar/tsup.config.ts
+++ b/packages/react-packages/sidebar/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['index.ts'],
+  format: ['esm', 'cjs'],
+  external: [/@emotion.*/, 'react'],
+  dts: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,29 @@
   resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.4.1.tgz#2d905f282304630e07bef6d02d2e7dbf3f0cc4e4"
   integrity sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==
 
+"@dt-dds/react-core@1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@dt-dds/react-core/-/react-core-1.0.0-beta.51.tgz#16a839af88845d6c30923163b231a02def3ccc62"
+  integrity sha512-Wj9ORs+xdGSsjD5xUFM2OWETskEiRU+il0tKTYhaD7EvIGvFqdmEn5tZBbt4EwSiaKhZ+nqY4C6jj+G4nS0Zig==
+  dependencies:
+    "@dt-dds/themes" "1.0.0-beta.9"
+
+"@dt-dds/react-icon@1.0.0-beta.54":
+  version "1.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@dt-dds/react-icon/-/react-icon-1.0.0-beta.54.tgz#7ee439c4b069c9c5b4f4a98b61f8afa49a1b3bc9"
+  integrity sha512-6Pq0UFgfLuFHSZDK1Iu/FUTcmVmva7Dzw1H+7rDbuzFQZAT0BHFLpNRNC7ZR20JjrTJAxXtVB9FGxWDSna1xCA==
+  dependencies:
+    "@dt-dds/icons" "1.0.0-beta.5"
+    "@dt-dds/react-core" "1.0.0-beta.51"
+    "@dt-dds/themes" "1.0.0-beta.9"
+
+"@dt-dds/themes@1.0.0-beta.9":
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@dt-dds/themes/-/themes-1.0.0-beta.9.tgz#0a43704ab1c75d78b33dcb1467dbffb5793dca47"
+  integrity sha512-5gkH57CjmbpH3ZKnH9SJ0o3YO8LUctphm1+4G2FOnNO+bTM4FjigcL3846pQ3wwhzOm5gf9wkmNpHG81smaksg==
+  dependencies:
+    tsx "^4.0.0"
+
 "@emnapi/core@^1.4.3":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.5.0.tgz#85cd84537ec989cebb2343606a1ee663ce4edaf0"
@@ -9825,16 +9848,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9939,14 +9953,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10958,7 +10965,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10971,15 +10978,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->
Adds a new Sidebar compound component package (`@dt-dds/react-sidebar`) for building navigation menus. State is managed externally via `useSidebar` hook.

### Features
- Presentational compound component architecture
- External state management via `useSidebar` hook
- Responsive design with mobile/desktop modes
- Auto-expand items based on URL navigation
- Support for custom link components (React Router, Next.js, etc.)

### Components
- `Sidebar` - Main container
- `Sidebar.Content` - Scrollable content area
- `Sidebar.Section` - Grouped navigation items
- `Sidebar.Header` / `Sidebar.Footer` - Semantic and structure sections
- `Sidebar.Item` - Navigation item with disclosure (expand/collapse) support
- `Sidebar.SubList` - Nested navigation items
- `Sidebar.Toggle` - Sidebar Expand/collapse button
- `Sidebar.Divider` - Visual separator

### Hooks
- `useSidebar` - External state management
- `useDisclosureState` - Item expand/collapse with auto-expand
- `useLocationPath` - URL tracking for active states

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [x] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-123