### PR TITLE
fix(changeset): include manual changesets in tag-packages.json

### DIFF
--- a/.changeset/tough-chairs-brake.md
+++ b/.changeset/tough-chairs-brake.md
@@ -1,5 +1,0 @@
----
-'@dt-dds/react-box': patch
----
-
-fix pkg publish by bumping version after npmjs.org unpublish

--- a/packages/changeset-conventional-commits/src/add-changesets.ts
+++ b/packages/changeset-conventional-commits/src/add-changesets.ts
@@ -58,9 +58,17 @@ export const conventionalCommitChangeset = async (
       ? changesets
       : difference(changesets, currentChangesets);
 
-  writePackageNamesToBeTagged(
-    newChangesets.map(({ releases }) => releases.map(({ name }) => name)).flat()
-  );
+  // Include packages from BOTH auto-generated AND existing manual changesets
+  const allAffectedPackages = [
+    ...newChangesets
+      .map(({ releases }) => releases.map(({ name }) => name))
+      .flat(),
+    ...currentChangesets
+      .map(({ releases }) => releases.map(({ name }) => name))
+      .flat(),
+  ];
+
+  writePackageNamesToBeTagged([...new Set(allAffectedPackages)]);
 
   newChangesets.forEach((changeset) => writeChangeset(changeset, cwd));
 };


### PR DESCRIPTION

## Description

Fixes broken manual generated changesets.  

Previously, only auto-generated changesets from conventional commits were written to `tag-packages.json`. 
Manual changesets created via `yarn changeset add` were processed  by changeset version but not included for tagging.

This fix ensures both auto-generated AND existing manual changesets are included in `tag-packages.json`, 
allowing `addTag` to properly create git tags.

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
