### PR TITLE
fix(scripts): correct package URL generation in README table

### DIFF
--- a/scripts/generate-pkg-list/index.js
+++ b/scripts/generate-pkg-list/index.js
@@ -17,6 +17,7 @@ const filterDtPackages = (packages) =>
 const createPackageInfo = (pkg) => ({
   name: pkg.packageJson.name,
   version: 'N/A',
+  path: pkg.dir.split('/packages/')[1],
 });
 
 // Pure function to fetch package version (returns a promise)
@@ -43,11 +44,8 @@ const updatePackageWithVersion = async (packageInfo) => ({
 });
 
 // Pure function to create table row
-const createTableRow = ({ name, version }) =>
-  `| [\`${name}\`](https://github.com/daimlertruck/DT-DDS/tree/main/packages/${name.replace(
-    '@dt-dds/',
-    ''
-  )}) | ${version} |`;
+const createTableRow = ({ name, version, path }) =>
+  `| [\`${name}\`](https://github.com/daimlertruck/DT-DDS/tree/main/packages/${path}) | ${version} |`;
 
 // Pure function to build markdown table
 const buildMarkdownTable = (packages) => {


### PR DESCRIPTION
## Description

The `createTableRow` function in [generate-pkg-list script](https://github.com/daimlertruck/DT-DDS/blob/main/scripts/generate-pkg-list/index.js#L46) was generating incorrect URLs by assuming all packages are directly under /packages/. Now uses pkg.dir to derive the actual path, correctly handling react-packages/* and dt-dds-react.

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
