### PR TITLE
fix: change hardcoded useMedia hook initial value

### DIFF
--- a/packages/react-packages/core/src/hooks/__tests__/useMedia.test.tsx
+++ b/packages/react-packages/core/src/hooks/__tests__/useMedia.test.tsx
@@ -79,4 +79,19 @@ describe('useMedia', () => {
 
     expect(result.current).toBe(true);
   });
+
+  it('should handle initial render when matchMedia is not available', () => {
+    // Temporarily remove matchMedia to simulate environments where it might not be available
+    const originalMatchMedia = window.matchMedia;
+    // @ts-expect-error - Intentionally removing matchMedia for testing
+    delete window.matchMedia;
+
+    const { result } = renderHook(() => useMedia('(max-width: 768px)'));
+
+    // Should default to false when matchMedia is not available
+    expect(result.current).toBe(false);
+
+    // Restore matchMedia
+    window.matchMedia = originalMatchMedia;
+  });
 });

--- a/packages/react-packages/core/src/hooks/useMedia.ts
+++ b/packages/react-packages/core/src/hooks/useMedia.ts
@@ -1,9 +1,18 @@
 import { useState, useEffect } from 'react';
 
 const useMedia = (query: string) => {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
 
   useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
     const media = window.matchMedia(query);
     if (media.matches !== matches) {
       setMatches(media.matches);


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->
**useMedia** hook initial state to prevent flash of incorrect content on first render. Components relying on useMedia for initial layout decisions (e.g., sidebar collapsed/expanded state) render with incorrect values on first paint

**Solution:** Use lazy initialization in useMedia to check window.matchMedia(query).matches on first render instead of hardcoding false, preventing the flash of incorrect content while remaining SSR-safe.


## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->
[DTFSMW-69](https://daimlertruck-cmk-1.atlassian.net/browse/DTFSMW-69)

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->


## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-145