### PR TITLE
fix: checkbox label alignment

### DIFF
--- a/packages/react-packages/checkbox/src/Checkbox.stories.tsx
+++ b/packages/react-packages/checkbox/src/Checkbox.stories.tsx
@@ -212,3 +212,26 @@ export const AllSizesAndStates: Story = {
     </div>
   ),
 };
+
+export const LongLabelWrapping: Story = {
+  render: () => (
+    <div
+      style={{
+        width: 300,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+      }}
+    >
+      <Checkbox
+        isChecked
+        label='This is a moderately long checkbox label that wraps in two lines'
+      />
+      <Checkbox
+        isChecked
+        label='Small checkbox with a long label that also wraps in two lines'
+        size='small'
+      />
+    </div>
+  ),
+};

--- a/packages/react-packages/checkbox/src/Checkbox.tsx
+++ b/packages/react-packages/checkbox/src/Checkbox.tsx
@@ -1,4 +1,10 @@
-import { ChangeEvent, forwardRef, useEffect, useRef } from 'react';
+import {
+  ChangeEvent,
+  forwardRef,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 
 import { useTheme } from '@emotion/react';
 
@@ -10,6 +16,7 @@ import {
   CheckboxLabelStyled,
   CheckboxBoxStyled,
 } from './Checkbox.styled';
+import { LABEL_LINE_HEIGHT, LABEL_HEIGHT_BUFFER } from './constants';
 import { CheckboxProps } from './types';
 import { mergeRefs } from './utils';
 
@@ -35,12 +42,27 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const theme = useTheme();
     const internalRef = useRef<HTMLInputElement | null>(null);
     const mergedRef = mergeRefs(internalRef, ref);
+    const labelRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
       if (internalRef.current) {
         internalRef.current.indeterminate = isIndeterminate;
       }
     }, [isIndeterminate]);
+
+    useLayoutEffect(() => {
+      if (!labelRef.current) return;
+
+      const labelContainer = labelRef.current.closest('label');
+      if (!labelContainer) return;
+
+      const el = labelRef.current;
+      const maxSingleLineHeight = LABEL_LINE_HEIGHT[size] + LABEL_HEIGHT_BUFFER;
+
+      const isWrapped = el.offsetHeight > maxSingleLineHeight;
+
+      labelContainer.style.alignItems = isWrapped ? 'flex-start' : 'center';
+    }, [label, children]);
 
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
       if (isDisabled) return;
@@ -96,7 +118,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         </CheckboxBoxStyled>
 
         {hasLabel ? (
-          <CheckboxLabelStyled $disabled={isDisabled} $size={size}>
+          <CheckboxLabelStyled
+            $disabled={isDisabled}
+            $size={size}
+            ref={labelRef}
+          >
             {label || children}
           </CheckboxLabelStyled>
         ) : null}

--- a/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
@@ -87,6 +87,7 @@ input:focus-visible+.emotion-4 {
     class="emotion-0 emotion-1"
     data-testid="checkbox"
     for="checkbox"
+    style="align-items: center;"
   >
     <input
       aria-invalid="false"

--- a/packages/react-packages/checkbox/src/constants/index.ts
+++ b/packages/react-packages/checkbox/src/constants/index.ts
@@ -1,4 +1,13 @@
+import { CheckboxSize } from '../types';
+
 export const SIZES = {
   small: 20,
   large: 24,
 } as const;
+
+export const LABEL_HEIGHT_BUFFER = 1;
+
+export const LABEL_LINE_HEIGHT: Record<CheckboxSize, number> = {
+  small: 16,
+  large: 20,
+};


### PR DESCRIPTION
## Description

Checkbox label should follow these rules:
- Single line: label should be centred 
- Two lines: label first line should be aligned with top of the box

## Issue

[ITCAPI-6577](https://jir.t3.daimlertruck.com/browse/ITCAPI-6577)

## Screenshots



<img width="560" height="259" alt="Screenshot 2025-12-22 at 19 27 34" src="https://github.com/user-attachments/assets/a40e0e93-e880-4ab6-868b-ba58642577f5" />

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-147