### PR TITLE
ci: relax blackduck scan failure severity to BLOCKER only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           blackducksca_url: ${{ env.BLACKDUCK_URL }}
           blackducksca_token: ${{ env.BLACKDUCK_TOKEN }}
-          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'
+          blackducksca_scan_failure_severities: 'BLOCKER'
           blackducksca_scan_full: ${{ github.ref == 'refs/heads/main' }}
           blackducksca_prComment_enabled: false
           detect_args: '--logging.level.detect=DEBUG --detect.blackduck.rapid.compare.mode=ALL --detect.project.version.phase=RELEASED  --detect.project.version.distribution=OPENSOURCE --detect.yarn.dependency.types.excluded=NON_PRODUCTION'


### PR DESCRIPTION
## Description

Remove CRITICAL from blackducksca_scan_failure_severities to only fail on BLOCKER severity issues. 
CRITICAL issues are still signalled during CI scan, but shipping is only blocked on BLOCKER.  

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->
https://github.com/daimlertruck/DT-DDS/issues/150 - Issue targetting the specific blackduck CRITICAL failure

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
