### PR TITLE
fix: pagination dependency

### DIFF
--- a/packages/react-packages/pagination/package.json
+++ b/packages/react-packages/pagination/package.json
@@ -23,7 +23,7 @@
     "@dt-dds/react-core": "1.0.0-beta.58",
     "@dt-dds/react-typography": "1.0.0-beta.49",
     "@dt-dds/react-icon": "1.0.0-beta.61",
-    "@dt-dds/icons": "1.0.0-beta.5",
+    "@dt-dds/icons": "1.0.0-beta.6",
     "@dt-dds/react-select": "1.0.0-beta.93",
     "@dt-dds/react-tooltip": "1.0.0-beta.68",
     "@dt-dds/themes": "1.0.0-beta.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,11 +1390,6 @@
   resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.4.1.tgz#2d905f282304630e07bef6d02d2e7dbf3f0cc4e4"
   integrity sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==
 
-"@dt-dds/icons@1.0.0-beta.5":
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@dt-dds/icons/-/icons-1.0.0-beta.5.tgz#5430d9c08cd77b3c423ea3fb4bf4bc19460c8213"
-  integrity sha512-SAXrreZDEeKB8aaZwddg7x1F1qpmUjn/K/fqq/QU6eOJkKNUfEhWjKNGhFvLXVuk9FIBoqviODUlxrHcVl0Dow==
-
 "@emnapi/core@^1.4.3":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.5.0.tgz#85cd84537ec989cebb2343606a1ee663ce4edaf0"


### PR DESCRIPTION
## Description

Bumpping Icon pkg version was missed during rebase which has cause this error  https://github.com/daimlertruck/DT-DDS/actions/runs/20748135812/job/59573014785#step:7:33 and the latest code not being published to npm 
this fix should solve the publish pagination issue. 
## Issue

[DTUI-62](https://jir.t3.daimlertruck.com/browse/DTUI-62)

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-153