### PR TITLE
fix: pagination button testid for current-page

### DIFF
--- a/packages/react-packages/pagination/src/Pagination.test.tsx
+++ b/packages/react-packages/pagination/src/Pagination.test.tsx
@@ -71,7 +71,7 @@ describe('<Pagination />', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('pagination-page-2'));
+    fireEvent.click(screen.getByTestId('pagination-current-page'));
     expect(onPageChange).not.toHaveBeenCalled();
   });
 

--- a/packages/react-packages/pagination/src/Pagination.tsx
+++ b/packages/react-packages/pagination/src/Pagination.tsx
@@ -142,7 +142,11 @@ export const Pagination = ({
               $isActive={page === currentPage}
               aria-current={page === currentPage ? 'page' : undefined}
               aria-label={`Go to page ${page}`}
-              data-testid={`pagination-page-${page}`}
+              data-testid={
+                page === currentPage
+                  ? 'pagination-current-page'
+                  : `pagination-page-${page}`
+              }
               key={page}
               onClick={() => handlePageChange(page as number)}
               title={`Go to page ${page}`}

--- a/packages/react-packages/pagination/src/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-packages/pagination/src/__snapshots__/Pagination.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`<Pagination /> should match snapshot 1`] = `
         aria-current="page"
         aria-label="Go to page 1"
         class="emotion-14 emotion-15"
-        data-testid="pagination-page-1"
+        data-testid="pagination-current-page"
         title="Go to page 1"
       >
         1


### PR DESCRIPTION
## Description

Add a default data-testid to the current page button that makes it easily identifiable
## Issue

NA

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-156