### PR TITLE
fix: checkbox box width reduction on long label

### DIFF
--- a/packages/react-packages/checkbox/src/Checkbox.styled.ts
+++ b/packages/react-packages/checkbox/src/Checkbox.styled.ts
@@ -105,6 +105,7 @@ export const CheckboxBoxStyled = styled('div', {
   align-items: center;
   justify-content: center;
   border-radius: ${({ theme }) => theme.shape.checkbox};
+  flex-shrink: 0;
 
   ${({ theme, $checked, $indeterminate, $disabled, $error, $size }) => {
     const state = getCheckboxState(

--- a/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-packages/checkbox/src/__snapshots__/Checkbox.test.tsx.snap
@@ -43,6 +43,9 @@ exports[`<Checkbox /> component renders checkbox correctly 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   border-radius: 0px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: 24px;
   width: 24px;
   background-color: #ffffff;


### PR DESCRIPTION
## Description

The problem:
<img width="352" height="104" alt="Screenshot 2026-01-13 at 23 11 26" src="https://github.com/user-attachments/assets/67e36216-b825-475b-a63f-2930cbcf3bea" />


When the Checkbox component is used in a constrained container like a Modal,
the flex box was shrinking the checkbox icon to accommodate long text.
Setting flex-shrink to 0 on the box should fix the issue.

## Issue

NA

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-158