### PR TITLE
fix: sidebar item HTML structure broken in production builds

### DIFF
--- a/packages/react-packages/icon-button/src/IconButton.tsx
+++ b/packages/react-packages/icon-button/src/IconButton.tsx
@@ -54,3 +54,5 @@ export const IconButton = ({
     </IconButtonStyled>
   );
 };
+
+IconButton.displayName = 'IconButton';

--- a/packages/react-packages/icon/src/Icon.tsx
+++ b/packages/react-packages/icon/src/Icon.tsx
@@ -35,3 +35,5 @@ export const Icon = ({
     </IconStyled>
   );
 };
+
+Icon.displayName = 'Icon';

--- a/packages/react-packages/sidebar/src/utils/__tests__/sidebarUtils.test.tsx
+++ b/packages/react-packages/sidebar/src/utils/__tests__/sidebarUtils.test.tsx
@@ -46,7 +46,7 @@ describe('sidebarUtils', () => {
       expect(isIconElement(<MockIconButton />)).toBe(true);
 
       const MockToggle = () => <span>toggle</span>;
-      MockToggle.displayName = 'SidebarToggle';
+      MockToggle.displayName = 'Sidebar.Toggle';
       expect(isIconElement(<MockToggle />)).toBe(true);
     });
 

--- a/packages/react-packages/sidebar/src/utils/sidebarUtils.ts
+++ b/packages/react-packages/sidebar/src/utils/sidebarUtils.ts
@@ -102,7 +102,7 @@ export const isIconElement = (child: ReactNode): boolean => {
   if (
     componentType?.displayName === 'Icon' ||
     componentType?.displayName === 'IconButton' ||
-    componentType?.displayName === 'SidebarToggle'
+    componentType?.displayName === 'Sidebar.Toggle'
   )
     return true;
   if (
@@ -122,7 +122,7 @@ export const isSidebarToggleElement = (child: ReactNode): boolean => {
   if (!isValidElement(child)) return false;
 
   const componentType = child.type as ElementType & { displayName?: string };
-  if (componentType?.displayName === 'SidebarToggle') return true;
+  if (componentType?.displayName === 'Sidebar.Toggle') return true;
 
   if (typeof child.type === 'function' && child.type.name === 'SidebarToggle')
     return true;


### PR DESCRIPTION
## Description

Issue: In production builds function names get minified, causing sidebar item icons to be incorrectly nested.
Fix: `displayName` is preserved through minification:
   - Add `displayName` to `Icon` and `IconButton` components
   - Update sidebarUtils to check for 'Sidebar.Toggle' displayName

Production build:
```html
  <!-- Before (bug): -->
  <a><span class="css-6oms2c"><i>icon</i>text</span></a>

  <!-- After (fix): -->
  <a><i>icon</i><span class="css-6oms2c">text</span></a>
```
 
<!-- Provide a detailed description about the nature of your PR and what it solves -->

## Issue
N/A
<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->
Bug:
<img width="261" height="151" alt="Screenshot 2026-01-14 at 12 02 53" src="https://github.com/user-attachments/assets/ae2931ca-29d1-4888-9f12-929b252596f1" />

Fix:
<img width="263" height="127" alt="Screenshot 2026-01-14 at 12 11 17" src="https://github.com/user-attachments/assets/e815b4aa-d9f5-4931-ad25-08af348e0e2d" />


## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-160