### PR TITLE
fix(ci): declare GHA permissions in workflows

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -28,6 +28,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
     if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,6 +56,8 @@ jobs:
   deploy-storybook:
     needs: build-storybook
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,6 +111,9 @@ jobs:
   change_pr_description:
     runs-on: ubuntu-latest
     needs: deploy-storybook
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -143,6 +150,9 @@ jobs:
   delete_previews:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore(release):')
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/gh-pages-cleanup.yml
+++ b/.github/workflows/gh-pages-cleanup.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
The repository workflows were relying on implicit default `GITHUB_TOKEN` permissions.

After the Enterprise Actions policy changed the default token permissions to read-only, workflow jobs that push changes or update pull requests started failing with permission errors.

Shoulfd fix [error](https://github.com/daimlertruck/DT-DDS/actions/runs/22833560369/job/66305005690#step:8:274)

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
