### PR TITLE
fix: textfield and tag components styling

### DIFF
--- a/packages/react-packages/tag/src/Tag.styled.ts
+++ b/packages/react-packages/tag/src/Tag.styled.ts
@@ -37,7 +37,7 @@ export const TagStyled = styled.div<TagStyledProps>(
     borderRadius: theme.radius[border === 'rounded' ? 'radius_70' : 'radius_0'],
     width: '150px',
 
-    ['> :first-child']: {
+    ['> span:first-of-type']: {
       whiteSpace: 'nowrap',
       display: 'block',
       overflow: 'hidden',

--- a/packages/react-packages/tag/src/__snapshots__/Tag.test.tsx.snap
+++ b/packages/react-packages/tag/src/__snapshots__/Tag.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<Tag /> component should render the tag with variant outlined, color se
   background-color: #696969;
 }
 
-.emotion-0>:first-child {
+.emotion-0>span:first-of-type {
   white-space: nowrap;
   display: block;
   overflow: hidden;
@@ -95,7 +95,7 @@ exports[`<Tag /> component should render the tag with variant solid, color error
   cursor: not-allowed;
 }
 
-.emotion-0>:first-child {
+.emotion-0>span:first-of-type {
   white-space: nowrap;
   display: block;
   overflow: hidden;
@@ -208,7 +208,7 @@ exports[`<Tag /> component should render the tag with variant solid, color infor
   color: #ffffff;
 }
 
-.emotion-0>:first-child {
+.emotion-0>span:first-of-type {
   white-space: nowrap;
   display: block;
   overflow: hidden;
@@ -259,7 +259,7 @@ exports[`<Tag /> component should render the tag with variant solid, color prima
   width: 150px;
 }
 
-.emotion-0>:first-child {
+.emotion-0>span:first-of-type {
   white-space: nowrap;
   display: block;
   overflow: hidden;
@@ -319,7 +319,7 @@ exports[`<Tag /> component should render the tag with variant solid, color warni
   color: #ffffff;
 }
 
-.emotion-0>:first-child {
+.emotion-0>span:first-of-type {
   white-space: nowrap;
   display: block;
   overflow: hidden;

--- a/packages/react-packages/text-field/src/TextField.stories.tsx
+++ b/packages/react-packages/text-field/src/TextField.stories.tsx
@@ -105,7 +105,7 @@ export const Default: StoryObj<TextFieldPropsWithExtrasProp> = {
     label: 'My label',
     id: '',
     message: 'Additional info',
-    initialValue: '',
+    initialValue: 'Initial value',
     maxLength: undefined,
     required: false,
     requiredMessage: '',

--- a/packages/react-packages/text-field/src/TextField.styled.ts
+++ b/packages/react-packages/text-field/src/TextField.styled.ts
@@ -225,39 +225,48 @@ export const InputWrapperStyled = styled.div<InputWrapperStyledProps>`
     width: 100%;
     color: ${theme.palette.content.default};
     background-color: ${getThemedBackgroundFill(backgroundFill, theme)};
-  
+
     ${
       variant === 'outlined'
         ? `border-radius: ${theme.shape.formField};
         border: 1px solid ${borderColor};
 
         &:focus-within,
-        &:hover:not([disabled]) { 
+        &:hover:not([disabled]) {
           border: 1px solid ${borderFocusColor};
         }
 
-        &:hover:([disabled]) { 
+        &:hover:([disabled]) {
           border: 1px solid ${borderColor};
+        }
+
+        &:has(input[readonly]:not([disabled])) {
+          background-color: ${theme.palette.surface.light};
+          border: 1px solid ${theme.palette.surface.default};
+
+          &:focus-within, &:hover {
+            border: 1px solid ${theme.palette.informative.default};
+          }
         }
       `
         : `border-radius: ${theme.shape.formField} ${theme.shape.formField} 0 0;
         border-bottom: 1px solid ${borderColor};
-        
+
         &:focus-within,
-        &:hover:not([disabled]) { 
-          border-bottom: 1px solid  ${borderFocusColor};
+        &:hover:not([disabled]) {
+          border-bottom: 1px solid ${borderFocusColor};
+        }
+
+        &:has(input[readonly]:not([disabled])) {
+          background-color: ${theme.palette.surface.light};
+          border-bottom: 1px solid ${theme.palette.surface.default};
+
+          &:focus-within, &:hover {
+            border-bottom: 1px solid ${theme.palette.informative.default};
+          }
         }
       `
     };
-
-    &:has(input[readonly]:not([disabled])) {
-      background-color: ${theme.palette.surface.light};
-      border: 1px solid ${theme.palette.surface.default};
-
-      &:focus-within, &:hover { 
-          border: 1px solid  ${theme.palette.informative.default};
-        }
-    }
 
     &:has(input[disabled]), &:has(input[disabled]) > * {
       cursor: not-allowed;

--- a/packages/react-packages/text-field/src/TextField.tsx
+++ b/packages/react-packages/text-field/src/TextField.tsx
@@ -86,7 +86,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     ref
   ) => {
     const [activeInput, setActiveInput] = useState(false);
-    const [inputValue, setInputValue] = useState('');
+    const [inputValue, setInputValue] = useState(initialValue ?? '');
     const [hasRequiredError, setHasRequiredError] = useState(false);
     const textFieldId = id ?? label.replaceAll(' ', '-').toLowerCase();
     const testId =

--- a/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-packages/text-field/src/__snapshots__/TextField.test.tsx.snap
@@ -980,12 +980,12 @@ exports[`<TextField /> component renders input with variant baseLine 1`] = `
 
 .emotion-5:has(input[readonly]:not([disabled])) {
   background-color: #f2f2f2;
-  border: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
 }
 
 .emotion-5:has(input[readonly]:not([disabled])):focus-within,
 .emotion-5:has(input[readonly]:not([disabled])):hover {
-  border: 1px solid #00677f;
+  border-bottom: 1px solid #00677f;
 }
 
 .emotion-5:has(input[disabled]),


### PR DESCRIPTION
## Description

Solves:
- floating label with initial value (check issue related).
- text input with readonly were always applying `outline` variant
- tag, changed the `first-child` selector to `:first-of-type` given it's unsafe for those using frameworks with server components.


## Issue

https://github.com/daimlertruck/DT-DDS/issues/161

## Screenshots

readonly (bottomLine), and initial value:
<img width="960" height="108" alt="image" src="https://github.com/user-attachments/assets/5e879558-5b99-4b22-a755-d24a22acee19" />


## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->

https://daimlertruck.github.io/DT-DDS/PR-191