### PR TITLE
ci: do not run storybook workflow in fork PRs

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -27,7 +27,9 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
-    if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
+    if: >-
+      !contains(github.event.head_commit.message, 'chore(release):') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

As Storybook workflow needs write access to deploy storybook to GitHub Pages, it can't be run on fork PRs, so it's a privileged workflow.

## Issue

N/A

## Screenshots

N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
