### PR TITLE
chore: fix build storybook action

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -29,7 +29,8 @@ jobs:
       cancel-in-progress: true
     if: >-
       !contains(github.event.head_commit.message, 'chore(release):') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository ||
+       github.ref == 'refs/heads/main')
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->
Updates the condition on the Storybook deploy job to also trigger when a PR is merged into main, not just on PR events from same repo branches.

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->
N/A

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->
N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
