### PR TITLE
docs: update first and default column in the board

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,6 @@
       - [Workflow](#workflow)
       - [Releasing](#releasing)
 
-
 # Prerequisites
 
 - Node.js >= v22
@@ -142,14 +141,14 @@ To propose a new feature:
 
 Our [project board](https://github.com/orgs/daimlertruck/projects/1) acts as the single source of truth for the status of all work items.
 
-| **Column**            | **Description**                                                                                                                                                                                                                                                                                                                                                                    | **Owner**                      |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **No Status (Inbox)** | **The Landing Zone.** All new issues arrive here automatically. They may be labelled as bug, feature, or question based on the template used.                                                                                                                                                                                                                                      | **Maintainers & Contributors** |
-| **Backlog**           | **To Be Refined.** Validated issues that need prioritization or scoping. Work does not start here.                                                                                                                                                                                                                                                                                 | **Maintainers Only**           |
-| **Ready**             | **Ready to be picked up.** Issues with clear requirements and approved scope. Contributors can assign themselves to these tasks.                                                                                                                                                                                                                                                   | **Maintainers & Contributors** |
-| **In Progress**       | **Active Work.** Tasks currently being worked on.                                                                                                                                                                                                                                                                                                                                  | **Assignee**                   |
-| **In Review**         | **PR Open.** Automatically moved here when a Pull Request is linked to the issue.<br><br>⭐️ Good practices:<br>- Target review time is 2 - 3 business days<br>- Required approvals: 2 developers, at least 1 of them is a maintainer<br>- Check the PR list and contribute with your review before taking a new task to work<br>- Contributors reviews are welcome and encouraged | **Reviewers**                  |
-| **Done**              | **Shipped.** Automatically moved here when the PR is merged.                                                                                                                                                                                                                                                                                                                       | **System**                     |
+| **Column**      | **Description**                                                                                                                                                                                                                                                                                                                                                                    | **Owner**                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Triage**      | **The Landing Zone.** All new issues arrive here automatically. They may be labelled as bug, feature, or question based on the template used.                                                                                                                                                                                                                                      | **Maintainers & Contributors** |
+| **Backlog**     | **To Be Refined.** Validated issues that need prioritization or scoping. Work does not start here.                                                                                                                                                                                                                                                                                 | **Maintainers Only**           |
+| **Ready**       | **Ready to be picked up.** Issues with clear requirements and approved scope. Contributors can assign themselves to these tasks.                                                                                                                                                                                                                                                   | **Maintainers & Contributors** |
+| **In Progress** | **Active Work.** Tasks currently being worked on.                                                                                                                                                                                                                                                                                                                                  | **Assignee**                   |
+| **In Review**   | **PR Open.** Automatically moved here when a Pull Request is linked to the issue.<br><br>⭐️ Good practices:<br>- Target review time is 2 - 3 business days<br>- Required approvals: 2 developers, at least 1 of them is a maintainer<br>- Check the PR list and contribute with your review before taking a new task to work<br>- Contributors reviews are welcome and encouraged | **Reviewers**                  |
+| **Done**        | **Shipped.** Automatically moved here when the PR is merged.                                                                                                                                                                                                                                                                                                                       | **System**                     |
 
 ## Triage & Refinement process
 
@@ -199,14 +198,14 @@ To ensure visibility for both Maintainers (who use the Board) and Contributors (
 
 Every column on the Board corresponds to a specific status label on the issue.
 
-| **Board Column**      | **Issue Label**        | **Description**                                                                              | **Who Acts?**              |
-| --------------------- | ---------------------- | -------------------------------------------------------------------------------------------- | -------------------------- |
-| **No Status (Inbox)** | status: triage 🟤      | **The Landing Zone.** Needs categorization to be done manually                               | Maintainers                |
-| **Backlog**           | status: backlog 🟠     | **To Be Refined.** Validated issues waiting for prioritization and/or clear scope.           | Maintainers                |
-| **Ready**             | status: ready 🟢       | **Ready to be picked up.** Issues with clear requirements and approved scope. Ready for dev. | Contributors & Maintainers |
-| **In Progress**       | status: in progress 🔵 | **Active Work.** Someone is currently working on this.                                       | Assignee                   |
-| **In Review**         | status: in review 🟣   | **PR Open.** A Pull Request is linked and under review.                                      | Reviewers                  |
-| **Done**              | (No status label)      | **Shipped.** The issue is closed.                                                            | System                     |
+| **Board Column** | **Issue Label**        | **Description**                                                                              | **Who Acts?**              |
+| ---------------- | ---------------------- | -------------------------------------------------------------------------------------------- | -------------------------- |
+| **Triage**       | status: triage 🟤      | **The Landing Zone.** Needs categorization to be done manually                               | Maintainers                |
+| **Backlog**      | status: backlog 🟠     | **To Be Refined.** Validated issues waiting for prioritization and/or clear scope.           | Maintainers                |
+| **Ready**        | status: ready 🟢       | **Ready to be picked up.** Issues with clear requirements and approved scope. Ready for dev. | Contributors & Maintainers |
+| **In Progress**  | status: in progress 🔵 | **Active Work.** Someone is currently working on this.                                       | Assignee                   |
+| **In Review**    | status: in review 🟣   | **PR Open.** A Pull Request is linked and under review.                                      | Reviewers                  |
+| **Done**         | (No status label)      | **Shipped.** The issue is closed.                                                            | System                     |
 
 ### Labels Categorization
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -56,7 +56,7 @@ To ensure high quality and clarity, every issue goes through a strict triage pro
 
 ### Phase 1: Initial Triage
 
-**Location:** _No Status_
+**Location:** _Triage_
 
 - **Questions:** If an issue is a `question`, Maintainers (or community members) answer it directly in the thread and close the issue. It does **not** continue in the board flow.
 - **Invalid Bugs:** If a bug is actually a user error or a misunderstanding provide feedback and close the issue.


### PR DESCRIPTION
## Description

Update documentation to remove "No Status" column and replace first/default column by "Triage". This change was already done directly in the board.

## Issue

N/A

## Screenshots

<img width="3181" height="1256" alt="image" src="https://github.com/user-attachments/assets/5c14bfe7-a8bc-47f6-9917-0fa497b83fa2" />

<img width="2453" height="749" alt="image" src="https://github.com/user-attachments/assets/fd3609eb-2955-43fd-bdab-9db0273a2dff" />

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [x] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [x] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
