### PR TITLE
chore(theme): move tsx to dev dependencies

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -36,10 +36,8 @@
     "jest": "^29.0.0",
     "ts-jest": "^29.4.0",
     "tsup": "^8.5.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.0.0"
-  },
-  "dependencies": {
-    "tsx": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

Move `tsx` from `dependencies` to `devDependencies` in `@dt-dds/themes`

tsx is only used at build time via the `build:theme` script. It has no runtime role — the package ships only compiled output from dist/.

Having it in dependencies caused it to be installed by library consumers, unnecessarily increasing their install footprint and exposing them to any vulnerabilities in tsx that they have no use for.

## Issue

- N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->
